### PR TITLE
Center map on user location and add operator marker

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -677,6 +677,49 @@ header {
   padding: 10px;
 }
 
+/* ---- User location marker ---- */
+
+.user-icon {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  background: #1e88e5;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  border: 2px solid #fff;
+  box-shadow: 0 0 10px rgba(30, 136, 229, 0.7);
+  width: auto !important;
+  height: auto !important;
+  transform: translate(-50%, -50%);
+}
+
+.user-icon-diamond {
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.user-icon-call {
+  font-family: monospace;
+  letter-spacing: 0.5px;
+}
+
+.user-popup-title {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--accent);
+  margin-bottom: 4px;
+}
+
+.user-popup-row {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
 /* ---- ISS ---- */
 
 .iss-icon {


### PR DESCRIPTION
Re-center map on configured location at startup, on location change, and on layout reset. Display a blue amateur radio marker with callsign at the operator's position.