### PR TITLE
Add 12/24h time format setting, move band conditions to header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,18 +45,33 @@
 
       <div class="splash-loc-status" id="splashLocStatus"></div>
 
+      <div class="splash-divider"></div>
+      <div class="splash-time-format">
+        <span class="splash-loc-title">Time Format</span>
+        <div class="splash-time-options">
+          <label><input type="radio" name="timeFormat" value="12" id="timeFmt12"> 12-hour</label>
+          <label><input type="radio" name="timeFormat" value="24" id="timeFmt24"> 24-hour</label>
+        </div>
+      </div>
+
       <button id="splashOk">OK</button>
     </div>
   </div>
 
   <header>
     <div class="header-left">
-      <div class="op-call" id="opCall"></div>
-      <div class="op-loc-row">
-        <span class="op-loc" id="opLoc">Location unknown</span>
+      <div class="op-info">
+        <div class="op-call" id="opCall"></div>
+        <div class="op-loc" id="opLoc">Location unknown</div>
+      </div>
+      <div class="op-btns">
         <button class="op-btn" id="editCallBtn" title="Edit callsign">Edit</button>
         <button class="op-btn" id="refreshLocBtn" title="Refresh location">Loc</button>
       </div>
+    </div>
+    <div class="header-center" id="headerBands">
+      <div class="header-bands-title">Band Conditions</div>
+      <div class="header-bands-row" id="headerBandsRow"></div>
     </div>
     <div class="header-right">
       <span class="last-updated" id="lastUpdated"></span>
@@ -135,22 +150,6 @@
       <div class="widget-header">Solar &amp; Propagation</div>
       <div class="widget-body">
         <div class="solar-indices" id="solarIndices"></div>
-      </div>
-      <div class="widget-resize"></div>
-    </div>
-
-    <!-- Band Conditions -->
-    <div class="widget" id="widget-bands">
-      <div class="widget-header">Band Conditions</div>
-      <div class="widget-body">
-        <div class="band-table-wrap">
-          <table class="band-table" id="bandTable">
-            <thead>
-              <tr><th>Band</th><th>Day</th><th>Night</th></tr>
-            </thead>
-            <tbody id="bandBody"></tbody>
-          </table>
-        </div>
       </div>
       <div class="widget-resize"></div>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -244,6 +244,36 @@ html, body {
   color: var(--red);
 }
 
+/* -- Time format section -- */
+
+.splash-time-format {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.splash-time-options {
+  display: flex;
+  gap: 12px;
+}
+
+.splash-time-options label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.82rem;
+  color: var(--text);
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
+.splash-time-options input[type="radio"] {
+  width: auto;
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
 /* ---- Header ---- */
 
 header {
@@ -258,6 +288,13 @@ header {
 }
 
 .header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.op-info {
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -280,15 +317,15 @@ header {
   text-decoration: underline;
 }
 
-.op-loc-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .op-loc {
   font-size: 0.72rem;
   color: var(--text-dim);
+}
+
+.op-btns {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .op-btn {
@@ -668,40 +705,50 @@ header {
   margin-top: 2px;
 }
 
-/* ---- Band conditions widget ---- */
+/* ---- Header band conditions strip ---- */
 
-.band-table-wrap {
-  padding: 8px 10px;
+.header-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
-.band-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.78rem;
+.header-bands-title {
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
 }
 
-.band-table th {
-  background: var(--surface2);
-  padding: 5px 6px;
-  text-align: center;
+.header-bands-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.header-band-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.header-band-name {
   color: var(--text-dim);
   font-weight: 600;
 }
 
-.band-table th:first-child {
-  text-align: left;
-}
-
-.band-table td {
-  padding: 4px 6px;
-  border-bottom: 1px solid var(--border);
-  text-align: center;
-}
-
-.band-table td:first-child {
-  text-align: left;
+.header-band-day,
+.header-band-night {
   font-weight: 600;
 }
+
 
 .cond-good { color: var(--green); font-weight: 600; }
 .cond-fair { color: var(--yellow); font-weight: 600; }


### PR DESCRIPTION
Time format:
- Add 12-hour / 24-hour radio toggle to the splash/edit screen
- Persist selection in localStorage (key: pota_time24), default 24h
- New fmtTime() helper wraps toLocaleTimeString with hour12 option
- All four time displays honor the setting: local clock, UTC clock, "Updated" timestamp, and spot time column
- Changing the setting immediately re-renders clocks and spot table

Band conditions relocated:
- Remove the dedicated Band Conditions widget from the right sidebar
- Display band conditions as a compact strip in the header center
- Simplifies the default layout from 3 right-side widgets to 2 (Solar and Lunar now split the right column 50/50)

Header restructured:
- Operator info (callsign + location) wrapped in .op-info container
- Edit/Loc buttons moved into vertical .op-btns group
- New .header-center section between operator info and controls
- Band conditions rendered as inline day/night pairs with color coding