### PR TITLE
Add widget visibility toggles to config screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
   <!-- Splash screen -->
   <div class="splash-overlay" id="splash">
     <div class="splash-box">
-      <h2>POTA Activations</h2>
+      <h2>HamTab Configuration</h2>
       <label for="splashCallsign">Your Callsign</label>
       <input type="text" id="splashCallsign" placeholder="e.g. W1AW" autocomplete="off" spellcheck="false" />
 
@@ -54,6 +54,12 @@
         </div>
       </div>
 
+      <div class="splash-divider"></div>
+      <div class="splash-widgets-section">
+        <span class="splash-loc-title">Widgets</span>
+        <div class="splash-widget-list" id="splashWidgetList"></div>
+      </div>
+
       <button id="splashOk">OK</button>
     </div>
   </div>
@@ -65,12 +71,12 @@
         <div class="op-loc" id="opLoc">Location unknown</div>
       </div>
       <div class="op-btns">
-        <button class="op-btn" id="editCallBtn" title="Edit callsign">Edit</button>
+        <button class="op-btn" id="editCallBtn" title="Configuration">Config</button>
         <button class="op-btn" id="refreshLocBtn" title="Refresh location">Loc</button>
       </div>
     </div>
     <div class="header-center" id="headerBands">
-      <div class="header-bands-title">Band Conditions</div>
+      <div class="header-bands-title">Band Conditions <span class="header-bands-hint">(Day / Night)</span></div>
       <div class="header-bands-row" id="headerBandsRow"></div>
     </div>
     <div class="header-right">
@@ -82,6 +88,7 @@
       </label>
       <button id="refreshBtn">Refresh</button>
       <button id="resetLayoutBtn" title="Reset widget layout">Reset Layout</button>
+      <button id="fullscreenBtn" title="Toggle fullscreen">Fullscreen</button>
       <button id="updateBtn" title="Check for updates">Update</button>
       <span id="updateStatus" class="update-status"></span>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -274,6 +274,38 @@ html, body {
   cursor: pointer;
 }
 
+/* -- Widget visibility section -- */
+
+.splash-widgets-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  text-align: left;
+}
+
+.splash-widget-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.splash-widget-list label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: var(--text);
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
+.splash-widget-list input[type="checkbox"] {
+  width: auto;
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
 /* ---- Header ---- */
 
 header {
@@ -406,6 +438,21 @@ header {
 }
 
 #updateBtn:hover {
+  background: var(--accent);
+}
+
+#fullscreenBtn {
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+#fullscreenBtn:hover {
   background: var(--accent);
 }
 
@@ -723,6 +770,15 @@ header {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
+}
+
+.header-bands-hint {
+  font-weight: 400;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  opacity: 0.7;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .header-bands-row {


### PR DESCRIPTION
Allow users to show/hide individual widgets from the HamTab Configuration splash screen. Visibility state persists in localStorage and resets when clicking "Reset Layout".