### PR TITLE
Add solar widget field config with proper XML parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^17.2.3",
         "express": "^4.21.0",
         "express-rate-limit": "^8.2.1",
+        "fast-xml-parser": "^5.3.4",
         "helmet": "^8.1.0",
         "selfsigned": "^2.4.1"
       }
@@ -344,6 +345,24 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/finalhandler": {
@@ -892,6 +911,18 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dotenv": "^17.2.3",
     "express": "^4.21.0",
     "express-rate-limit": "^8.2.1",
+    "fast-xml-parser": "^5.3.4",
     "helmet": "^8.1.0",
     "selfsigned": "^2.4.1"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -64,6 +64,15 @@
     </div>
   </div>
 
+  <!-- Solar field config overlay -->
+  <div class="splash-overlay hidden" id="solarCfgSplash">
+    <div class="splash-box solar-cfg-box">
+      <h2>Solar &amp; Propagation Fields</h2>
+      <div class="splash-widget-list" id="solarFieldList"></div>
+      <button id="solarCfgOk">OK</button>
+    </div>
+  </div>
+
   <header>
     <div class="header-left">
       <div class="op-info">
@@ -154,7 +163,7 @@
 
     <!-- Solar -->
     <div class="widget" id="widget-solar">
-      <div class="widget-header">Solar &amp; Propagation</div>
+      <div class="widget-header">Solar &amp; Propagation <button class="widget-cfg-btn" id="solarCfgBtn" title="Configure fields">&#9881;</button></div>
       <div class="widget-body">
         <div class="solar-indices" id="solarIndices"></div>
       </div>

--- a/public/style.css
+++ b/public/style.css
@@ -514,6 +514,29 @@ header {
   border-bottom: 1px solid var(--border);
 }
 
+.widget-cfg-btn {
+  float: right;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.widget-cfg-btn:hover {
+  opacity: 1;
+  color: var(--text);
+}
+
+.solar-cfg-box .splash-widget-list {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
 .widget-body {
   flex: 1;
   overflow: auto;


### PR DESCRIPTION
Replace regex-based solar XML parsing with fast-xml-parser and extract all available fields (solar wind, Bz, proton/electron flux, aurora, geomag field, helium line, MUF, etc.). Add a gear button to the solar widget header that opens a field-selection overlay where users can toggle which fields appear as cards. Selections persist in localStorage and are preserved across layout resets.