### PR TITLE
Fix SSRF DNS rebinding and remove stray merge conflict marker

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -131,7 +131,6 @@
     return '';
   }
 
-<<<<<<< HEAD
   // Lunar field registry (single source of truth)
   const LUNAR_FIELD_DEFS = [
     // Currently displayed (default: visible)

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const cors = require('cors');
 const rateLimit = require('express-rate-limit');
 const selfsigned = require('selfsigned');
 const { XMLParser } = require('fast-xml-parser');
+const dns = require('dns');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -43,22 +44,9 @@ app.use(cors({
 
     try {
       const { hostname } = new URL(origin);
-
-      // Allow localhost
-      if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+      if (hostname === 'localhost' || isPrivateIP(hostname)) {
         return callback(null, true);
       }
-
-      // Allow RFC 1918 private ranges
-      const parts = hostname.split('.').map(Number);
-      if (parts.length === 4 && parts.every(p => !isNaN(p))) {
-        const [a, b] = parts;
-        if (a === 10) return callback(null, true);                          // 10.0.0.0/8
-        if (a === 172 && b >= 16 && b <= 31) return callback(null, true);   // 172.16.0.0/12
-        if (a === 192 && b === 168) return callback(null, true);            // 192.168.0.0/16
-      }
-
-      // Reject public origins
       callback(new Error('CORS not allowed'));
     } catch {
       callback(new Error('CORS not allowed'));
@@ -331,21 +319,38 @@ const MAX_REDIRECTS = 5;
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024; // 5 MB
 const REQUEST_TIMEOUT_MS = 10000; // 10 seconds
 
-function isPrivateHost(hostname) {
-  // Block localhost
-  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
-  // Block IPv4 private ranges
-  const parts = hostname.split('.').map(Number);
+function isPrivateIP(ip) {
+  // IPv6 loopback and private
+  if (ip === '::1') return true;
+  if (ip.startsWith('fc') || ip.startsWith('fd')) return true; // unique local
+  if (ip.startsWith('fe80')) return true; // link-local
+  if (ip === '::' || ip.startsWith('::ffff:')) {
+    // IPv4-mapped IPv6 — extract and check the IPv4 part
+    const v4 = ip.replace('::ffff:', '');
+    if (v4 !== ip) return isPrivateIP(v4);
+  }
+
+  // IPv4
+  const parts = ip.split('.').map(Number);
   if (parts.length === 4 && parts.every(p => !isNaN(p) && p >= 0 && p <= 255)) {
     const [a, b] = parts;
+    if (a === 0) return true;
     if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true;
     if (a === 172 && b >= 16 && b <= 31) return true;
     if (a === 192 && b === 168) return true;
-    if (a === 169 && b === 254) return true; // link-local
-    if (a === 127) return true;
-    if (a === 0) return true;
   }
   return false;
+}
+
+async function resolveHost(hostname) {
+  // If it's already an IP literal, return it directly
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.includes(':')) {
+    return hostname;
+  }
+  const { address } = await dns.promises.lookup(hostname);
+  return address;
 }
 
 function secureFetch(url, redirectCount = 0) {
@@ -361,40 +366,54 @@ function secureFetch(url, redirectCount = 0) {
       return reject(new Error('Only HTTPS URLs are allowed'));
     }
 
-    // SSRF guard: block private/internal IPs
-    if (isPrivateHost(parsed.hostname)) {
-      return reject(new Error('Requests to private addresses are blocked'));
-    }
-
-    const req = https.get(url, { headers: { 'User-Agent': 'POTA-App/1.0' } }, (resp) => {
-      if (resp.statusCode >= 300 && resp.statusCode < 400 && resp.headers.location) {
-        resp.resume(); // drain socket
-        return secureFetch(resp.headers.location, redirectCount + 1).then(resolve).catch(reject);
-      }
-      if (resp.statusCode !== 200) {
-        resp.resume(); // drain socket
-        return reject(new Error(`HTTP ${resp.statusCode}`));
+    // Resolve DNS and check the actual IP before connecting
+    resolveHost(parsed.hostname).then((resolvedIP) => {
+      if (isPrivateIP(resolvedIP)) {
+        return reject(new Error('Requests to private addresses are blocked'));
       }
 
-      let data = '';
-      let bytes = 0;
-      resp.on('data', (chunk) => {
-        bytes += chunk.length;
-        if (bytes > MAX_RESPONSE_BYTES) {
-          resp.destroy();
-          return reject(new Error('Response too large'));
+      // Pin the resolved IP to prevent TOCTOU / DNS rebinding
+      const options = {
+        hostname: resolvedIP,
+        path: parsed.pathname + parsed.search,
+        port: parsed.port || 443,
+        headers: {
+          'User-Agent': 'POTA-App/1.0',
+          'Host': parsed.hostname,
+        },
+        servername: parsed.hostname, // for TLS SNI
+      };
+
+      const req = https.get(options, (resp) => {
+        if (resp.statusCode >= 300 && resp.statusCode < 400 && resp.headers.location) {
+          resp.resume();
+          return secureFetch(resp.headers.location, redirectCount + 1).then(resolve).catch(reject);
         }
-        data += chunk;
-      });
-      resp.on('end', () => resolve(data));
-      resp.on('error', reject);
-    });
+        if (resp.statusCode !== 200) {
+          resp.resume();
+          return reject(new Error(`HTTP ${resp.statusCode}`));
+        }
 
-    req.on('error', reject);
-    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
-      req.destroy();
-      reject(new Error('Request timed out'));
-    });
+        let data = '';
+        let bytes = 0;
+        resp.on('data', (chunk) => {
+          bytes += chunk.length;
+          if (bytes > MAX_RESPONSE_BYTES) {
+            resp.destroy();
+            return reject(new Error('Response too large'));
+          }
+          data += chunk;
+        });
+        resp.on('end', () => resolve(data));
+        resp.on('error', reject);
+      });
+
+      req.on('error', reject);
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy();
+        reject(new Error('Request timed out'));
+      });
+    }).catch(reject);
   });
 }
 
@@ -479,13 +498,11 @@ const KEY_PATH = path.join(CERTS_DIR, 'server.key');
 const CERT_PATH = path.join(CERTS_DIR, 'server.cert');
 
 function isRFC1918(ip) {
+  // Subset of isPrivateIP: only RFC 1918 LAN-routable ranges (for TLS cert SANs)
   const parts = ip.split('.').map(Number);
   if (parts.length !== 4 || parts.some(p => isNaN(p))) return false;
   const [a, b] = parts;
-  if (a === 10) return true;                          // 10.0.0.0/8
-  if (a === 172 && b >= 16 && b <= 31) return true;   // 172.16.0.0/12
-  if (a === 192 && b === 168) return true;             // 192.168.0.0/16
-  return false;
+  return (a === 10) || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
 }
 
 function getLocalIPs() {


### PR DESCRIPTION
Resolve hostnames to IPs before connecting in secureFetch() to prevent DNS rebinding attacks. Check the resolved IP (not the hostname string) against private ranges, and pin the resolved IP for the connection to eliminate TOCTOU races. Consolidate CORS origin check to use shared isPrivateIP(). Remove stray git conflict marker that broke client-side JS initialization.

Fixes #8