### PR TITLE
Add callsign license lookup and privilege filter for US operators

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,6 +155,8 @@
           <select id="countryFilter"><option value="">All Countries</option></select>
           <select id="stateFilter"><option value="">All States</option></select>
           <select id="gridFilter"><option value="">All Grids</option></select>
+          <!-- US callsigns only -->
+          <label class="priv-filter-label" title="Only show spots within your US license privileges"><input type="checkbox" id="privFilter"> My privileges</label>
         </div>
         <div class="table-wrap">
           <table id="spotsTable">

--- a/public/style.css
+++ b/public/style.css
@@ -645,6 +645,28 @@ header {
   appearance: auto;
 }
 
+/* ---- Privilege filter checkbox ---- */
+
+.priv-filter-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.priv-filter-label input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+  cursor: pointer;
+}
+
+.priv-filter-label.hidden {
+  display: none;
+}
+
 .table-wrap {
   flex: 1;
   overflow-y: auto;

--- a/server.js
+++ b/server.js
@@ -139,6 +139,22 @@ app.get('/api/lunar', (req, res) => {
   }
 });
 
+// Proxy callook.info license lookup
+app.get('/api/callsign/:call', async (req, res) => {
+  try {
+    const call = encodeURIComponent(req.params.call.toUpperCase());
+    const data = await fetchJSON(`https://callook.info/${call}/json`);
+    res.json({
+      status: data.status || 'INVALID',
+      class: (data.current && data.current.operClass) || '',
+      name: (data.name || ''),
+    });
+  } catch (err) {
+    console.error('Error fetching callsign data:', err.message);
+    res.status(502).json({ error: 'Failed to fetch callsign data' });
+  }
+});
+
 // --- Auto-update system ---
 
 const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';


### PR DESCRIPTION
Proxy callook.info API to look up license class, store in localStorage, and add a "My privileges" checkbox that filters spots to frequencies the operator is authorized to use based on their license class.