### PR TITLE
Add map markers for SOTA spots by enriching with summit coordinates

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -60,7 +60,7 @@
         { key: 'spotTime',   label: 'Time',     class: '' },
       ],
       filters: ['band', 'mode'],
-      hasMap: false,
+      hasMap: true,
       spotId: (s) => `${s.callsign}-${s.reference}-${s.frequency}`,
       sortKey: 'spotTime',
     },
@@ -270,7 +270,6 @@
   const lunarCfgSplash = document.getElementById('lunarCfgSplash');
   const lunarFieldList = document.getElementById('lunarFieldList');
   const lunarCfgOk = document.getElementById('lunarCfgOk');
-<<<<<<< HEAD
   const propContainer = document.getElementById('propContainer');
   const spotsHead = document.getElementById('spotsHead');
   const sourceTabs = document.getElementById('sourceTabs');
@@ -354,8 +353,6 @@
     btn.addEventListener('mousedown', (e) => e.stopPropagation());
     btn.addEventListener('click', () => switchSource(btn.dataset.source));
   });
-=======
->>>>>>> e5aa8344211064a757a6c6d8c40e14ead57dad26
 
   // --- Operator callsign & location ---
 


### PR DESCRIPTION
Fetch lat/lon from the SOTA summit details API for each unique summit reference, cache results in memory, and merge coordinates into spot data. Enable the map for SOTA on the client. Also resolve lingering merge conflict markers in app.js that broke the splash screen.