### PR TITLE
Add Band Ref button with license privilege reference popup

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -273,6 +273,11 @@
   const lunarCfgSplash = document.getElementById('lunarCfgSplash');
   const lunarFieldList = document.getElementById('lunarFieldList');
   const lunarCfgOk = document.getElementById('lunarCfgOk');
+  const bandRefBtn = document.getElementById('bandRefBtn');
+  const bandRefSplash = document.getElementById('bandRefSplash');
+  const bandRefOk = document.getElementById('bandRefOk');
+  const bandRefMyPriv = document.getElementById('bandRefMyPriv');
+  const bandRefContent = document.getElementById('bandRefContent');
   const propContainer = document.getElementById('propContainer');
   const spotsHead = document.getElementById('spotsHead');
   const sourceTabs = document.getElementById('sourceTabs');
@@ -755,6 +760,56 @@
   }
 
   lunarCfgOk.addEventListener('click', dismissLunarCfg);
+
+  // --- Band reference popup ---
+
+  bandRefBtn.addEventListener('click', () => {
+    renderBandRef();
+    bandRefSplash.classList.remove('hidden');
+  });
+
+  bandRefOk.addEventListener('click', () => {
+    bandRefSplash.classList.add('hidden');
+  });
+
+  bandRefMyPriv.addEventListener('change', () => {
+    renderBandRef();
+  });
+
+  function renderBandRef() {
+    const myPrivOnly = bandRefMyPriv.checked;
+    const hasClass = isUSCallsign(myCallsign) && !!licenseClass;
+
+    // If no US license class, disable checkbox and show all
+    bandRefMyPriv.disabled = !hasClass;
+    if (!hasClass) bandRefMyPriv.checked = false;
+
+    const MODE_LABELS = { all: 'All', cw: 'CW', cwdig: 'CW/Digital', phone: 'Phone' };
+
+    let classesToShow;
+    if (myPrivOnly && hasClass) {
+      classesToShow = [licenseClass.toUpperCase()];
+    } else {
+      classesToShow = ['EXTRA', 'GENERAL', 'TECHNICIAN', 'NOVICE'];
+    }
+
+    const CLASS_DISPLAY = { EXTRA: 'Extra', GENERAL: 'General', TECHNICIAN: 'Technician', NOVICE: 'Novice' };
+
+    let html = '';
+    for (const cls of classesToShow) {
+      const privs = US_PRIVILEGES[cls];
+      if (!privs) continue;
+      html += `<h3>${CLASS_DISPLAY[cls] || cls}</h3>`;
+      html += '<table class="band-ref-table"><thead><tr><th>Band</th><th>Frequency Range (MHz)</th><th>Modes</th></tr></thead><tbody>';
+      for (const [lo, hi, modes] of privs) {
+        const band = freqToBand(String(lo)) || '?';
+        html += `<tr><td>${band}</td><td>${lo} – ${hi}</td><td>${MODE_LABELS[modes] || modes}</td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+
+    bandRefContent.innerHTML = html;
+  }
 
   // --- Bidirectional lat/lon <-> grid sync ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -94,6 +94,19 @@
     </div>
   </div>
 
+  <!-- Band privilege reference overlay -->
+  <div class="splash-overlay hidden" id="bandRefSplash">
+    <div class="splash-box band-ref-box">
+      <h2>Band Privilege Reference</h2>
+      <label class="band-ref-filter">
+        <input type="checkbox" id="bandRefMyPriv" checked />
+        My privileges only
+      </label>
+      <div id="bandRefContent"></div>
+      <button class="splash-btn" id="bandRefOk">Close</button>
+    </div>
+  </div>
+
   <header>
     <div class="header-left">
       <div class="op-info">
@@ -104,6 +117,7 @@
       <div class="op-btns">
         <button class="op-btn" id="editCallBtn" title="Configuration">Config</button>
         <button class="op-btn" id="refreshLocBtn" title="Refresh location">Loc</button>
+        <button class="op-btn" id="bandRefBtn" title="Band privilege reference">Band Ref</button>
       </div>
     </div>
     <div class="header-center" id="headerBands">

--- a/public/style.css
+++ b/public/style.css
@@ -594,6 +594,69 @@ header {
   overflow-y: auto;
 }
 
+/* ---- Band reference popup ---- */
+
+.band-ref-box {
+  max-width: 520px;
+  max-height: 80vh;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.band-ref-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: var(--text);
+  margin-bottom: 12px;
+  cursor: pointer;
+}
+
+.band-ref-filter input[type="checkbox"] {
+  width: auto;
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
+.band-ref-box h3 {
+  font-size: 0.9rem;
+  color: var(--yellow);
+  margin: 10px 0 4px;
+}
+
+.band-ref-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+  margin-bottom: 8px;
+}
+
+.band-ref-table th {
+  background: var(--surface2);
+  padding: 4px 6px;
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+}
+
+.band-ref-table td {
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.band-ref-table td:first-child {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.band-ref-table td:nth-child(2) {
+  font-family: monospace;
+  color: var(--yellow);
+}
+
 .widget-body {
   flex: 1;
   overflow: auto;


### PR DESCRIPTION
Adds a "Band Ref" button to the header that opens a modal showing US amateur band privileges (frequency ranges and allowed modes) per license class. A "My privileges only" checkbox filters the table to the user's license class; unchecking shows all four classes. Non-US callsigns see the checkbox disabled with all classes displayed.