### PR TITLE
Highlight selected spot marker and its cluster with orange

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1190,6 +1190,8 @@ header {
 .marker-cluster-medium div { background-color: rgba(255, 214, 0, 0.7); color: #111; }
 .marker-cluster-large { background-color: rgba(233, 69, 96, 0.4); }
 .marker-cluster-large div { background-color: rgba(233, 69, 96, 0.7); color: #fff; }
+.marker-cluster-selected { background-color: rgba(255, 152, 0, 0.4) !important; }
+.marker-cluster-selected div { background-color: rgba(255, 152, 0, 0.7) !important; color: #fff !important; }
 
 /* ---- Clock widget ---- */
 


### PR DESCRIPTION
When a spot is selected via table row or map click, swap the marker to an orange SVG pin icon. If the marker is aggregated into a cluster at the current zoom level, the cluster dot also turns orange. Selection persists across popup close, re-selection, zoom changes, and data refresh.