### PR TITLE
Add local weather display and day/night indicator to clocks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,16 @@
       </div>
 
       <div class="splash-divider"></div>
+      <div class="splash-wx-section">
+        <span class="splash-loc-title">Weather Station (optional)</span>
+        <input type="text" id="splashWxStation" placeholder="e.g. KCTBRIDG45" autocomplete="off" spellcheck="false" style="text-transform:uppercase;margin-top:6px;" />
+        <div style="font-size:0.7rem;color:var(--text-dim);margin-top:-10px;margin-bottom:8px;text-align:left;">Weather Underground station ID</div>
+        <label for="splashWxApiKey">WU API Key</label>
+        <input type="text" id="splashWxApiKey" placeholder="Weather Underground API key" autocomplete="off" spellcheck="false" style="text-transform:none;" />
+        <div style="font-size:0.7rem;color:var(--text-dim);margin-top:-10px;margin-bottom:8px;text-align:left;"><a href="https://www.wunderground.com/member/api-keys" target="_blank" style="color:var(--accent);">Get a free API key</a></div>
+      </div>
+
+      <div class="splash-divider"></div>
       <div class="splash-widgets-section">
         <span class="splash-loc-title">Widgets</span>
         <div class="splash-widget-list" id="splashWidgetList"></div>
@@ -160,9 +170,11 @@
       <div class="widget-header">Local Time <button class="widget-cfg-btn" id="clockLocalCfgBtn" title="Configure clock style">&#9881;</button></div>
       <div class="widget-body">
         <div class="clock-display" id="clockLocal">
+          <span class="clock-daynight" id="clockLocalDayNight"></span>
           <div class="clock-time" id="clockLocalTime"></div>
           <div class="clock-day-date" id="clockLocalDate"></div>
           <canvas class="clock-analog-canvas" id="clockLocalCanvas" width="200" height="200"></canvas>
+          <div class="clock-weather" id="clockLocalWeather"></div>
         </div>
       </div>
       <div class="widget-resize"></div>
@@ -173,6 +185,7 @@
       <div class="widget-header">UTC <button class="widget-cfg-btn" id="clockUtcCfgBtn" title="Configure clock style">&#9881;</button></div>
       <div class="widget-body">
         <div class="clock-display" id="clockUtc">
+          <span class="clock-daynight" id="clockUtcDayNight"></span>
           <div class="clock-time" id="clockUtcTime"></div>
           <div class="clock-day-date" id="clockUtcDate"></div>
           <canvas class="clock-analog-canvas" id="clockUtcCanvas" width="200" height="200"></canvas>

--- a/public/style.css
+++ b/public/style.css
@@ -1238,6 +1238,41 @@ header {
   flex-shrink: 0;
 }
 
+/* ---- Day/Night indicator ---- */
+
+.clock-daynight {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  font-size: 1.2rem;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.clock-daynight.day {
+  color: var(--yellow);
+}
+
+.clock-daynight.night {
+  color: var(--text-dim);
+}
+
+/* ---- Weather in local clock ---- */
+
+.clock-weather {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--text-dim);
+  text-align: center;
+  line-height: 1.4;
+  letter-spacing: 0;
+  margin-top: 2px;
+}
+
+.clock-display {
+  position: relative;
+}
+
 /* ---- Propagation widget ---- */
 
 .prop-controls {


### PR DESCRIPTION
Weather Underground integration via user-provided API key and station ID in config splash. Server proxies WU PWS API with 1-day fallback when station returns 204. Both clocks show sun/moon icon based on client-side sunrise/sunset calculation using operator location.