### PR TITLE
Add map overlay config (lat/lon grid, Maidenhead, timezones) and cloc…

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -40,6 +40,19 @@
   let propLayer = null;
   let propLabelLayer = null;
 
+  // Map overlay state
+  const MAP_OVERLAY_KEY = 'hamtab_map_overlays';
+  let mapOverlays = { latLonGrid: false, maidenheadGrid: false, timezoneGrid: false };
+  try {
+    const saved = JSON.parse(localStorage.getItem(MAP_OVERLAY_KEY));
+    if (saved) Object.assign(mapOverlays, saved);
+  } catch (e) {}
+  function saveMapOverlays() { localStorage.setItem(MAP_OVERLAY_KEY, JSON.stringify(mapOverlays)); }
+  let latLonLayer = null;
+  let maidenheadLayer = null;
+  let timezoneLayer = null;
+  let maidenheadDebounceTimer = null;
+
   // Widget registry (single source of truth)
   const WIDGET_DEFS = [
     { id: 'widget-clock-local', name: 'Local Time' },
@@ -295,8 +308,7 @@
   const clockStyleDigital = document.getElementById('clockStyleDigital');
   const clockStyleAnalog = document.getElementById('clockStyleAnalog');
   let clockStyle = localStorage.getItem('hamtab_clock_style') || 'digital';
-  const clockLocalDayNight = document.getElementById('clockLocalDayNight');
-  const clockUtcDayNight = document.getElementById('clockUtcDayNight');
+  // clockLocalDayNight removed — indicator now in time text
   const clockLocalWeather = document.getElementById('clockLocalWeather');
   const splashWxStation = document.getElementById('splashWxStation');
   const splashWxApiKey = document.getElementById('splashWxApiKey');
@@ -817,6 +829,185 @@
 
   lunarCfgOk.addEventListener('click', dismissLunarCfg);
 
+  // --- Map overlay config ---
+
+  const mapOverlayCfgBtn = document.getElementById('mapOverlayCfgBtn');
+  const mapOverlayCfgSplash = document.getElementById('mapOverlayCfgSplash');
+  const mapOverlayCfgOk = document.getElementById('mapOverlayCfgOk');
+  const mapOvLatLon = document.getElementById('mapOvLatLon');
+  const mapOvMaidenhead = document.getElementById('mapOvMaidenhead');
+  const mapOvTimezone = document.getElementById('mapOvTimezone');
+
+  if (mapOverlayCfgBtn) {
+    mapOverlayCfgBtn.addEventListener('mousedown', (e) => { e.stopPropagation(); });
+    mapOverlayCfgBtn.addEventListener('click', () => {
+      mapOvLatLon.checked = mapOverlays.latLonGrid;
+      mapOvMaidenhead.checked = mapOverlays.maidenheadGrid;
+      mapOvTimezone.checked = mapOverlays.timezoneGrid;
+      mapOverlayCfgSplash.classList.remove('hidden');
+    });
+  }
+
+  if (mapOverlayCfgOk) {
+    mapOverlayCfgOk.addEventListener('click', () => {
+      mapOverlays.latLonGrid = mapOvLatLon.checked;
+      mapOverlays.maidenheadGrid = mapOvMaidenhead.checked;
+      mapOverlays.timezoneGrid = mapOvTimezone.checked;
+      saveMapOverlays();
+      mapOverlayCfgSplash.classList.add('hidden');
+      renderAllMapOverlays();
+    });
+  }
+
+  function renderAllMapOverlays() {
+    if (!map) return;
+    renderLatLonGrid();
+    renderMaidenheadGrid();
+    renderTimezoneGrid();
+  }
+
+  function renderLatLonGrid() {
+    if (latLonLayer) { map.removeLayer(latLonLayer); latLonLayer = null; }
+    if (!mapOverlays.latLonGrid) return;
+
+    latLonLayer = L.layerGroup().addTo(map);
+    const zoom = map.getZoom();
+    let spacing = 30;
+    if (zoom >= 8) spacing = 1;
+    else if (zoom >= 6) spacing = 5;
+    else if (zoom >= 3) spacing = 10;
+
+    const bounds = map.getBounds();
+    const labelLon = bounds.getWest() + (bounds.getEast() - bounds.getWest()) * 0.01;
+    const labelLat = bounds.getSouth() + (bounds.getNorth() - bounds.getSouth()) * 0.01;
+    const lineStyle = { color: '#4a90e2', weight: 1, opacity: 0.3, pane: 'mapOverlays', interactive: false };
+    const equatorStyle = { color: '#4a90e2', weight: 3, opacity: 0.6, pane: 'mapOverlays', interactive: false };
+    const pmStyle = { color: '#4a90e2', weight: 2, opacity: 0.5, pane: 'mapOverlays', interactive: false };
+
+    // Horizontal lines (lat)
+    for (let lat = -90; lat <= 90; lat += spacing) {
+      const style = lat === 0 ? equatorStyle : lineStyle;
+      L.polyline([[ lat, -180 ], [ lat, 180 ]], style).addTo(latLonLayer);
+      if (lat >= bounds.getSouth() && lat <= bounds.getNorth()) {
+        const ns = lat === 0 ? 'EQ' : (lat > 0 ? lat + '°N' : Math.abs(lat) + '°S');
+        L.marker([lat, labelLon], {
+          icon: L.divIcon({ className: 'grid-label latlon-label' + (lat === 0 ? ' latlon-equator' : ''), html: ns, iconSize: null }),
+          pane: 'mapOverlays', interactive: false
+        }).addTo(latLonLayer);
+      }
+    }
+    // Vertical lines (lon)
+    for (let lon = -180; lon <= 180; lon += spacing) {
+      const style = lon === 0 ? pmStyle : lineStyle;
+      L.polyline([[ -85, lon ], [ 85, lon ]], style).addTo(latLonLayer);
+      if (lon >= bounds.getWest() && lon <= bounds.getEast()) {
+        const ew = lon === 0 ? 'PM' : (lon > 0 ? lon + '°E' : Math.abs(lon) + '°W');
+        L.marker([labelLat, lon], {
+          icon: L.divIcon({ className: 'grid-label latlon-label', html: ew, iconSize: null }),
+          pane: 'mapOverlays', interactive: false
+        }).addTo(latLonLayer);
+      }
+    }
+  }
+
+  function renderMaidenheadGrid() {
+    if (maidenheadLayer) { map.removeLayer(maidenheadLayer); maidenheadLayer = null; }
+    if (!mapOverlays.maidenheadGrid) return;
+
+    maidenheadLayer = L.layerGroup().addTo(map);
+    const zoom = map.getZoom();
+    const bounds = map.getBounds();
+    const south = bounds.getSouth(), north = bounds.getNorth();
+    const west = bounds.getWest(), east = bounds.getEast();
+
+    if (zoom <= 5) {
+      // 2-char fields: 20° lon × 10° lat
+      const lonStep = 20, latStep = 10;
+      const lonStart = Math.floor((west + 180) / lonStep) * lonStep - 180;
+      const latStart = Math.floor((south + 90) / latStep) * latStep - 90;
+      for (let lon = lonStart; lon < east && lon < 180; lon += lonStep) {
+        for (let lat = latStart; lat < north && lat < 90; lat += latStep) {
+          const fieldLon = Math.floor((lon + 180) / 20);
+          const fieldLat = Math.floor((lat + 90) / 10);
+          if (fieldLon < 0 || fieldLon > 17 || fieldLat < 0 || fieldLat > 17) continue;
+          const label = String.fromCharCode(65 + fieldLon) + String.fromCharCode(65 + fieldLat);
+          L.rectangle([[lat, lon], [lat + latStep, lon + lonStep]], {
+            color: '#ff6b35', weight: 1.5, fill: false, pane: 'mapOverlays', interactive: false
+          }).addTo(maidenheadLayer);
+          L.marker([lat + latStep / 2, lon + lonStep / 2], {
+            icon: L.divIcon({ className: 'grid-label maidenhead-label', html: label, iconSize: null }),
+            pane: 'mapOverlays', interactive: false
+          }).addTo(maidenheadLayer);
+        }
+      }
+    } else if (zoom <= 9) {
+      // 4-char squares: 2° lon × 1° lat
+      const lonStep = 2, latStep = 1;
+      const lonStart = Math.floor((west + 180) / lonStep) * lonStep - 180;
+      const latStart = Math.floor((south + 90) / latStep) * latStep - 90;
+      for (let lon = lonStart; lon < east && lon < 180; lon += lonStep) {
+        for (let lat = latStart; lat < north && lat < 90; lat += latStep) {
+          const fieldLon = Math.floor((lon + 180) / 20);
+          const fieldLat = Math.floor((lat + 90) / 10);
+          if (fieldLon < 0 || fieldLon > 17 || fieldLat < 0 || fieldLat > 17) continue;
+          const sqLon = Math.floor(((lon + 180) % 20) / 2);
+          const sqLat = Math.floor(((lat + 90) % 10) / 1);
+          const label = String.fromCharCode(65 + fieldLon) + String.fromCharCode(65 + fieldLat) + sqLon + sqLat;
+          L.rectangle([[lat, lon], [lat + latStep, lon + lonStep]], {
+            color: '#ff6b35', weight: 1, fill: false, pane: 'mapOverlays', interactive: false
+          }).addTo(maidenheadLayer);
+          L.marker([lat + latStep / 2, lon + lonStep / 2], {
+            icon: L.divIcon({ className: 'grid-label maidenhead-label-sm', html: label, iconSize: null }),
+            pane: 'mapOverlays', interactive: false
+          }).addTo(maidenheadLayer);
+        }
+      }
+    } else {
+      // 6-char subsquares: 5' lon × 2.5' lat
+      const lonStep = 5 / 60, latStep = 2.5 / 60;
+      const lonStart = Math.floor(west / lonStep) * lonStep;
+      const latStart = Math.floor(south / latStep) * latStep;
+      for (let lon = lonStart; lon < east && lon < 180; lon += lonStep) {
+        for (let lat = latStart; lat < north && lat < 90; lat += latStep) {
+          const aLon = lon + 180, aLat = lat + 90;
+          if (aLon < 0 || aLon >= 360 || aLat < 0 || aLat >= 180) continue;
+          const fLon = Math.floor(aLon / 20), fLat = Math.floor(aLat / 10);
+          const sLon = Math.floor((aLon % 20) / 2), sLat = Math.floor((aLat % 10) / 1);
+          const ssLon = Math.floor(((aLon % 2) / (5 / 60))), ssLat = Math.floor(((aLat % 1) / (2.5 / 60)));
+          L.rectangle([[lat, lon], [lat + latStep, lon + lonStep]], {
+            color: '#ff6b35', weight: 0.5, fill: false, opacity: 0.5, pane: 'mapOverlays', interactive: false
+          }).addTo(maidenheadLayer);
+          if (zoom >= 12) {
+            const label = String.fromCharCode(65 + fLon) + String.fromCharCode(65 + fLat) + sLon + sLat +
+              String.fromCharCode(97 + Math.min(ssLon, 23)) + String.fromCharCode(97 + Math.min(ssLat, 23));
+            L.marker([lat + latStep / 2, lon + lonStep / 2], {
+              icon: L.divIcon({ className: 'grid-label maidenhead-label-xs', html: label, iconSize: null }),
+              pane: 'mapOverlays', interactive: false
+            }).addTo(maidenheadLayer);
+          }
+        }
+      }
+    }
+  }
+
+  function renderTimezoneGrid() {
+    if (timezoneLayer) { map.removeLayer(timezoneLayer); timezoneLayer = null; }
+    if (!mapOverlays.timezoneGrid) return;
+
+    timezoneLayer = L.layerGroup().addTo(map);
+    const lineStyle = { color: '#9b59b6', weight: 1.5, opacity: 0.4, dashArray: '5,5', pane: 'mapOverlays', interactive: false };
+
+    for (let i = -12; i <= 12; i++) {
+      const lon = i * 15;
+      L.polyline([[-85, lon], [85, lon]], lineStyle).addTo(timezoneLayer);
+      const label = 'UTC' + (i === 0 ? '' : (i > 0 ? '+' + i : '' + i));
+      L.marker([70, lon], {
+        icon: L.divIcon({ className: 'grid-label timezone-label', html: label, iconSize: null }),
+        pane: 'mapOverlays', interactive: false
+      }).addTo(timezoneLayer);
+    }
+  }
+
   // --- Clock config overlay ---
 
   clockLocalCfgBtn.addEventListener('mousedown', (e) => { e.stopPropagation(); });
@@ -1071,7 +1262,12 @@
 
   if (hasLeaflet) {
     try {
-      map = L.map('map').setView([39.8, -98.5], 4);
+      map = L.map('map', {
+        worldCopyJump: true,
+        maxBoundsViscosity: 1.0,
+        maxBounds: [[-90, -180], [90, 180]],
+        minZoom: 2,
+      }).setView([39.8, -98.5], 4);
       L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
         attribution: '&copy; OpenStreetMap &copy; CARTO',
         maxZoom: 19,
@@ -1107,6 +1303,30 @@
       // Propagation contour overlay
       map.createPane('propagation');
       map.getPane('propagation').style.zIndex = 300;
+
+      // Map overlays pane (above propagation, below markers)
+      map.createPane('mapOverlays');
+      map.getPane('mapOverlays').style.zIndex = 350;
+      map.getPane('mapOverlays').style.pointerEvents = 'none';
+
+      // Map overlay event listeners
+      map.on('zoomend', () => {
+        if (mapOverlays.latLonGrid) renderLatLonGrid();
+        if (mapOverlays.maidenheadGrid) {
+          clearTimeout(maidenheadDebounceTimer);
+          maidenheadDebounceTimer = setTimeout(renderMaidenheadGrid, 150);
+        }
+      });
+      map.on('moveend', () => {
+        if (mapOverlays.latLonGrid) renderLatLonGrid();
+        if (mapOverlays.maidenheadGrid) {
+          clearTimeout(maidenheadDebounceTimer);
+          maidenheadDebounceTimer = setTimeout(renderMaidenheadGrid, 150);
+        }
+      });
+
+      // Initial render of saved overlays
+      setTimeout(renderAllMapOverlays, 200);
     } catch (e) {
       console.error('Map initialization failed:', e);
       map = null;
@@ -2506,20 +2726,33 @@
     '<path d="M36 8a24 24 0 1 0 0 48 20 20 0 0 1 0-48z" fill="#b0bec5"/>' +
     '</svg>';
 
+  function isDaytime(lat, lon, date) {
+    try {
+      const times = getSunTimes(lat, lon, date);
+      if (times.sunrise && times.sunset) {
+        return date >= times.sunrise && date < times.sunset;
+      }
+    } catch (e) {}
+    // Fallback: rough estimate using solar noon at longitude
+    const utcHour = date.getUTCHours() + date.getUTCMinutes() / 60;
+    const solarNoon = 12 - lon / 15;
+    const diff = Math.abs(((utcHour - solarNoon) + 24) % 24 - 12);
+    return diff < 6;
+  }
+
+  let lastLocalDay = null;
+  let lastUtcDay = null;
+
   function updateDayNight() {
-    if (myLat === null || myLon === null) {
-      clockLocalDayNight.innerHTML = '';
-      clockUtcDayNight.innerHTML = '';
-      return;
-    }
     const now = new Date();
-    const { sunrise, sunset } = getSunTimes(myLat, myLon, now);
-    const isDay = sunrise && sunset && now >= sunrise && now < sunset;
-    const svg = isDay ? SVG_SUN : SVG_MOON;
-    clockLocalDayNight.innerHTML = svg;
-    clockLocalDayNight.className = 'clock-daynight';
-    clockUtcDayNight.innerHTML = svg;
-    clockUtcDayNight.className = 'clock-daynight';
+    // Local day/night based on user location
+    if (myLat !== null && myLon !== null) {
+      lastLocalDay = isDaytime(myLat, myLon, now);
+    } else {
+      lastLocalDay = null;
+    }
+    // UTC day/night based on Greenwich (51.48°N, 0°W)
+    lastUtcDay = isDaytime(51.48, 0, now);
   }
 
   // --- Weather fetch (WU PWS) ---
@@ -2679,9 +2912,12 @@
   function updateClocks() {
     const now = new Date();
     const dateOpts = { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' };
-    clockLocalTime.textContent = fmtTime(now);
-    clockLocalDate.textContent = now.toLocaleDateString(undefined, dateOpts);
-    clockUtcTime.textContent = fmtTime(now, { timeZone: 'UTC' });
+    const localIcon = lastLocalDay === true ? '☀️' : lastLocalDay === false ? '🌙' : '';
+    const utcIcon = lastUtcDay === true ? '☀️' : lastUtcDay === false ? '🌙' : '';
+    const localTime = fmtTime(now);
+    const utcTime = fmtTime(now, { timeZone: 'UTC' });
+    clockLocalTime.innerHTML = (localIcon ? '<span class="daynight-emoji">' + localIcon + '</span> ' : '') + esc(localTime);
+    clockUtcTime.innerHTML = (utcIcon ? '<span class="daynight-emoji">' + utcIcon + '</span> ' : '') + esc(utcTime);
     clockUtcDate.textContent = now.toLocaleDateString(undefined, Object.assign({ timeZone: 'UTC' }, dateOpts));
     if (clockStyle === 'analog') {
       drawAnalogClock(clockLocalCanvas, now);

--- a/public/index.html
+++ b/public/index.html
@@ -171,7 +171,6 @@
       <div class="widget-body">
         <div class="wx-alert-badge hidden" id="wxAlertBadge">&#9888;</div>
         <div class="clock-display" id="clockLocal">
-          <span class="clock-daynight" id="clockLocalDayNight"></span>
           <div class="clock-time" id="clockLocalTime"></div>
           <div class="clock-day-date" id="clockLocalDate"></div>
           <canvas class="clock-analog-canvas" id="clockLocalCanvas" width="200" height="200"></canvas>
@@ -187,7 +186,6 @@
       <div class="widget-header">UTC <button class="widget-cfg-btn" id="clockUtcCfgBtn" title="Configure clock style">&#9881;</button></div>
       <div class="widget-body">
         <div class="clock-display" id="clockUtc">
-          <span class="clock-daynight" id="clockUtcDayNight"></span>
           <div class="clock-time" id="clockUtcTime"></div>
           <div class="clock-day-date" id="clockUtcDate"></div>
           <canvas class="clock-analog-canvas" id="clockUtcCanvas" width="200" height="200"></canvas>
@@ -235,6 +233,7 @@
     <!-- Map -->
     <div class="widget" id="widget-map">
       <div class="widget-header">HamMap
+        <button class="widget-cfg-btn" id="mapOverlayCfgBtn" title="Map overlays">&#9881;</button>
         <div class="prop-controls">
           <button class="prop-metric-btn" data-metric="off">Prop Off</button>
           <button class="prop-metric-btn active" data-metric="mufd">MUF</button>
@@ -268,6 +267,19 @@
         <div class="lunar-cards" id="lunarCards"></div>
       </div>
       <div class="widget-resize"></div>
+    </div>
+  </div>
+
+  <!-- Map overlay config overlay -->
+  <div class="splash-overlay hidden" id="mapOverlayCfgSplash">
+    <div class="splash-box map-overlay-cfg-box">
+      <h2>Map Overlays</h2>
+      <div class="splash-widget-list" id="mapOverlayFieldList">
+        <label><input type="checkbox" id="mapOvLatLon" /> Lat/Lon Grid</label>
+        <label><input type="checkbox" id="mapOvMaidenhead" /> Grid Squares (Maidenhead)</label>
+        <label><input type="checkbox" id="mapOvTimezone" /> Timezone Lines</label>
+      </div>
+      <button id="mapOverlayCfgOk">OK</button>
     </div>
   </div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -1205,6 +1205,7 @@ header {
   font-weight: 700;
   color: var(--text);
   letter-spacing: 1px;
+  position: relative;
 }
 
 .clock-time {
@@ -1238,22 +1239,12 @@ header {
   flex-shrink: 0;
 }
 
-/* ---- Day/Night indicator ---- */
+/* ---- Day/Night indicator (emoji prepended to clock time text) ---- */
 
-.clock-daynight {
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  width: 24px;
-  height: 24px;
-  pointer-events: none;
-}
-
-.clock-daynight svg {
-  width: 100%;
-  height: 100%;
-  display: block;
-  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.4));
+.daynight-emoji {
+  font-style: normal;
+  text-shadow: none;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif;
 }
 
 /* ---- Weather in local clock ---- */
@@ -1266,10 +1257,6 @@ header {
   line-height: 1.4;
   letter-spacing: 0;
   margin-top: 2px;
-}
-
-.clock-display {
-  position: relative;
 }
 
 /* ---- Propagation widget ---- */
@@ -1553,6 +1540,58 @@ header {
 
 .wx-alert-link a:hover {
   text-decoration: underline;
+}
+
+/* ---- Map overlay grid labels ---- */
+
+.leaflet-mapOverlays-pane,
+.leaflet-mapOverlays-pane * {
+  pointer-events: none !important;
+}
+
+.grid-label {
+  background: none !important;
+  border: none !important;
+  pointer-events: none !important;
+  white-space: nowrap;
+  font-family: monospace;
+  font-weight: 600;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.9), -1px -1px 2px rgba(0,0,0,0.9);
+}
+
+.latlon-label {
+  color: #4a90e2;
+  font-size: 0.65rem;
+}
+
+.latlon-equator {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #64b5f6;
+}
+
+.maidenhead-label {
+  color: #ff6b35;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.maidenhead-label-sm {
+  color: #ff6b35;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.maidenhead-label-xs {
+  color: #ff6b35;
+  font-size: 0.55rem;
+  font-weight: 600;
+}
+
+.timezone-label {
+  color: #9b59b6;
+  font-size: 0.7rem;
+  font-weight: 600;
 }
 
 /* ---- Scrollbar ---- */


### PR DESCRIPTION
…k day/night indicators

- Gear button on map widget opens overlay config with 3 toggles
- Lat/lon grid: adaptive spacing by zoom, highlighted equator/prime meridian, viewport-relative labels
- Maidenhead grid: 2-char fields, 4-char squares, 6-char subsquares by zoom level
- Timezone lines: dashed purple lines at 15° intervals with UTC labels
- Overlays persist via localStorage, render in dedicated non-interactive pane
- Constrain map to single world copy (maxBounds, worldCopyJump, minZoom: 2)
- Day/night emoji indicators on both Local and UTC clock widgets
- UTC day/night computed independently using Greenwich coordinates