### PR TITLE
Add Raspberry Pi install script and save WU API key to .env from config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,16 @@ HamTabV1 is a POTA/SOTA amateur radio dashboard. Node.js/Express backend, vanill
 - Bump `version` in `package.json` on every push: patch for fixes, minor for features
 - Rebuild (`npm run build`) after bumping to update the client bundle
 
-## API & Security Guidelines
+## Security (Priority)
 
-- All external API calls go through server.js proxy — never from client directly
-- No API keys in client code — use `.env` for secrets
-- Rate limiting on all `/api/` routes
-- CORS locked to private networks
+Security is a top priority. Flag any code that could introduce a vulnerability.
+
+- **SSRF prevention** — All outbound requests in server.js must resolve the hostname and reject RFC 1918 / loopback IPs before connecting. Whitelist URL path/query params where possible (e.g. SDO image type).
+- **No client-side external requests** — All external API calls go through server.js proxy, never from the browser directly.
+- **Secrets** — No API keys in client code. Use `.env` for secrets. Never commit `.env` or TLS certs.
+- **CSP** — Helmet CSP is enforced. When adding new external resources, proxy them through the server rather than loosening CSP.
+- **CORS** — Locked to RFC 1918 private networks only.
+- **Rate limiting** — All `/api/` routes are rate-limited.
+- **Input validation** — Sanitize and whitelist all user-supplied query params on server endpoints. Use `encodeURIComponent` on the client when building URLs.
+- **XSS** — Use `textContent` or DOM APIs to render user/API data. Never inject unsanitized strings via `innerHTML`. The `esc()` utility must be used if HTML insertion is unavoidable.
+- **Dependency hygiene** — Keep dependencies minimal. Audit before adding new packages.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,40 @@ npm install
 npm start
 ```
 
+### Raspberry Pi
+
+The included install script handles everything: installs Node.js if needed, copies the app to `/opt/hamtab`, configures Weather Underground, and optionally sets up a systemd service for boot-start with automatic crash recovery.
+
+```bash
+git clone https://github.com/stevencheist/HamTabv1.git
+cd HamTabv1
+sudo bash install.sh
+```
+
+The installer will prompt you to:
+
+1. **Weather Underground** — Choose whether to use WU for weather data, and enter your API key (or add it later via the Config screen in the browser)
+2. **Start on boot** — If yes, installs a systemd service that starts HamTab automatically and restarts on failure
+
+After install, the app runs from `/opt/hamtab`. Manage it with:
+
+```bash
+sudo systemctl status hamtab      # check status
+sudo journalctl -u hamtab -f      # tail logs
+sudo systemctl restart hamtab     # restart
+sudo systemctl stop hamtab        # stop
+```
+
+To reinstall or update, pull the latest code and re-run the installer:
+
+```bash
+cd ~/HamTabv1
+git pull
+sudo bash install.sh
+```
+
+> **Note:** The WU API key can also be set from the Config splash screen in the browser — it saves directly to the server's `.env` file so all LAN clients share it.
+
 ### Windows
 
 **Prerequisites:**

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# HamTab — Raspberry Pi install script
+# Usage: clone the repo anywhere, then run: bash install.sh
+
+set -e
+
+INSTALL_DIR="/opt/hamtab"
+SERVICE_NAME="hamtab"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Require root ---
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run with sudo:"
+  echo "  sudo bash install.sh"
+  exit 1
+fi
+
+# --- Detect the calling user (not root) ---
+REAL_USER="${SUDO_USER:-pi}"
+REAL_HOME=$(eval echo "~$REAL_USER")
+
+echo "==================================="
+echo "  HamTab Installer"
+echo "==================================="
+echo ""
+echo "  Install dir:  $INSTALL_DIR"
+echo "  Run as user:  $REAL_USER"
+echo ""
+
+# --- Check for Node.js ---
+if ! command -v node &>/dev/null; then
+  echo "Node.js not found. Installing via NodeSource ..."
+  curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+  apt-get install -y nodejs
+fi
+
+NODE_VER=$(node --version)
+echo "Node.js $NODE_VER found."
+echo ""
+
+# --- Copy to standard location ---
+if [ "$SCRIPT_DIR" != "$INSTALL_DIR" ]; then
+  echo "Copying files to $INSTALL_DIR ..."
+  mkdir -p "$INSTALL_DIR"
+  rsync -a --delete \
+    --exclude node_modules \
+    --exclude .git \
+    --exclude .env \
+    "$SCRIPT_DIR/" "$INSTALL_DIR/"
+  chown -R "$REAL_USER":"$REAL_USER" "$INSTALL_DIR"
+else
+  echo "Already in $INSTALL_DIR, skipping copy."
+fi
+
+# --- .env setup ---
+if [ ! -f "$INSTALL_DIR/.env" ]; then
+  echo ""
+  read -rp "Use Weather Underground for weather data? [y/N] " WU_CHOICE
+  WU_CHOICE="${WU_CHOICE:-N}"
+
+  if [[ "$WU_CHOICE" =~ ^[Yy] ]]; then
+    read -rp "Enter your WU API key (or press Enter to add later): " WU_KEY
+    echo "WU_API_KEY=$WU_KEY" > "$INSTALL_DIR/.env"
+    if [ -z "$WU_KEY" ]; then
+      echo ".env created. Add your key later in $INSTALL_DIR/.env"
+    else
+      echo ".env created with API key."
+    fi
+  else
+    echo "WU_API_KEY=" > "$INSTALL_DIR/.env"
+    echo ".env created (WU disabled)."
+  fi
+  chown "$REAL_USER":"$REAL_USER" "$INSTALL_DIR/.env"
+else
+  echo "Existing .env found, keeping it."
+fi
+
+# --- Install dependencies ---
+echo ""
+echo "Installing npm dependencies ..."
+cd "$INSTALL_DIR"
+sudo -u "$REAL_USER" npm install
+
+# --- Build client bundle ---
+echo "Building client ..."
+sudo -u "$REAL_USER" npm run build
+
+# --- Systemd service ---
+echo ""
+read -rp "Start HamTab on boot? [Y/n] " BOOT_CHOICE
+BOOT_CHOICE="${BOOT_CHOICE:-Y}"
+
+if [[ "$BOOT_CHOICE" =~ ^[Yy] ]]; then
+  cat > /etc/systemd/system/${SERVICE_NAME}.service <<EOF
+[Unit]
+Description=HamTab POTA/SOTA Dashboard
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$REAL_USER
+WorkingDirectory=$INSTALL_DIR
+ExecStart=/usr/bin/node server.js
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=5
+Environment=NODE_ENV=production
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hamtab
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable "$SERVICE_NAME"
+  systemctl restart "$SERVICE_NAME"
+
+  echo ""
+  echo "Service installed and started."
+  echo ""
+  echo "  Status:   sudo systemctl status $SERVICE_NAME"
+  echo "  Logs:     sudo journalctl -u $SERVICE_NAME -f"
+  echo "  Restart:  sudo systemctl restart $SERVICE_NAME"
+  echo "  Stop:     sudo systemctl stop $SERVICE_NAME"
+else
+  echo ""
+  echo "Skipping boot service. Start manually with:"
+  echo "  cd $INSTALL_DIR && npm start"
+fi
+
+echo ""
+echo "Install complete."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hamtab",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "HamTab — POTA + SOTA ham radio dashboard with map and solar data",
   "main": "server.js",
   "scripts": {

--- a/public/app.js
+++ b/public/app.js
@@ -2815,7 +2815,7 @@
     $("splashGridDropdown").classList.remove("open");
     $("splashGridDropdown").innerHTML = "";
     state_default.gridHighlightIdx = -1;
-    $("splashVersion").textContent = "0.2.0";
+    $("splashVersion").textContent = "0.3.0";
     $("splashCallsign").focus();
   }
   function dismissSplash() {
@@ -2833,6 +2833,14 @@
     state_default.wxApiKey = ($("splashWxApiKey").value || "").trim();
     localStorage.setItem("hamtab_wx_station", state_default.wxStation);
     localStorage.setItem("hamtab_wx_apikey", state_default.wxApiKey);
+    if (state_default.wxApiKey) {
+      fetch("/api/config/env", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ WU_API_KEY: state_default.wxApiKey })
+      }).catch(() => {
+      });
+    }
     fetchWeather();
     const widgetList = document.getElementById("splashWidgetList");
     widgetList.querySelectorAll('input[type="checkbox"]').forEach((cb) => {

--- a/src/splash.js
+++ b/src/splash.js
@@ -234,6 +234,16 @@ function dismissSplash() {
   state.wxApiKey = ($('splashWxApiKey').value || '').trim();
   localStorage.setItem('hamtab_wx_station', state.wxStation);
   localStorage.setItem('hamtab_wx_apikey', state.wxApiKey);
+
+  // Persist WU API key to server .env so all clients share it
+  if (state.wxApiKey) {
+    fetch('/api/config/env', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ WU_API_KEY: state.wxApiKey }),
+    }).catch(() => {});
+  }
+
   fetchWeather();
 
   const widgetList = document.getElementById('splashWidgetList');


### PR DESCRIPTION
- Add install.sh: copies app to /opt/hamtab, installs deps, builds, optionally sets up systemd service with auto-restart on failure
- Add /api/config/env endpoint to persist WU API key from splash screen to server .env so all LAN clients share it
- Add Raspberry Pi installation docs to README
- Update security and code conventions in CLAUDE.md
- Bump version to 0.3.0