### PR TITLE
Add animated SDO solar time-lapse with frame cycling on canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hamtab",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "HamTab — POTA + SOTA ham radio dashboard with map and solar data",
   "main": "server.js",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -263,7 +263,10 @@
             <option value="0304">AIA 304 Å</option>
             <option value="HMIIC">HMI Intensitygram</option>
           </select>
-          <img id="solarImage" alt="SDO Solar Image" />
+          <div class="solar-canvas-wrap">
+            <canvas id="solarCanvas" width="200" height="200"></canvas>
+            <button class="solar-play-btn" id="solarPlayBtn" title="Play/Pause">&#9654;</button>
+          </div>
         </div>
         <div class="solar-indices" id="solarIndices"></div>
       </div>
@@ -274,7 +277,7 @@
     <div class="widget" id="widget-lunar">
       <div class="widget-header">Lunar / EME <button class="widget-cfg-btn" id="lunarCfgBtn" title="Configure fields">&#9881;</button></div>
       <div class="widget-body">
-        <canvas id="moonCanvas" width="80" height="80"></canvas>
+        <canvas id="moonCanvas" width="160" height="160"></canvas>
         <div class="lunar-cards" id="lunarCards"></div>
       </div>
       <div class="widget-resize"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -993,12 +993,42 @@ header {
   padding: 8px 10px 0;
 }
 
-.solar-image-container img {
-  max-width: 200px;
-  border-radius: 6px;
-  display: block;
+.solar-canvas-wrap {
+  position: relative;
+  display: inline-block;
   margin: 6px auto 0;
+}
+
+#solarCanvas {
+  display: block;
+  border-radius: 6px;
   background: #000;
+  max-width: 200px;
+}
+
+.solar-play-btn {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 0.65rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+  line-height: 1;
+  padding: 0;
+}
+
+.solar-play-btn:hover {
+  opacity: 1;
 }
 
 .solar-image-container select {


### PR DESCRIPTION
Adds /api/solar/frames and /api/solar/frame/:filename server endpoints to fetch and proxy SDO browse images. Client preloads last 48 frames and cycles them on a canvas at 200ms intervals with play/pause control. Falls back to single latest image if frames unavailable.