### PR TITLE
Add regression harness + fix callsign Cache-Control bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hamtab",
-  "version": "0.70.1",
+  "version": "0.70.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hamtab",
-      "version": "0.70.1",
+      "version": "0.70.2",
       "dependencies": {
         "cors": "^2.8.6",
         "dotenv": "^17.2.3",
@@ -24,7 +24,8 @@
       },
       "devDependencies": {
         "marked": "^15.0.0",
-        "puppeteer": "^24.0.0"
+        "puppeteer": "^24.0.0",
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -477,6 +478,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
@@ -658,6 +682,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -670,6 +701,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/b4a": {
       "version": "1.7.3",
@@ -998,11 +1036,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commist": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
       "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
       "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -1067,6 +1128,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1147,6 +1215,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1172,6 +1250,17 @@
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -1276,6 +1365,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1548,6 +1653,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-unique-numbers": {
       "version": "9.0.26",
       "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.26.tgz",
@@ -1622,6 +1734,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1771,6 +1918,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3072,6 +3235,90 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/swagger-ui-dist": {
       "version": "5.31.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build:docs": "node docs/user-guide/build.mjs",
     "dev": "node esbuild.mjs --watch",
     "start": "node esbuild.mjs && node server.js",
-    "start:direct": "node server.js"
+    "start:direct": "node server.js",
+    "test": "node --test test/unit/ test/smoke/"
   },
   "dependencies": {
     "cors": "^2.8.6",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "marked": "^15.0.0",
-    "puppeteer": "^24.0.0"
+    "puppeteer": "^24.0.0",
+    "supertest": "^7.2.2"
   }
 }

--- a/server/middleware/cache-control.js
+++ b/server/middleware/cache-control.js
@@ -32,7 +32,7 @@ const CACHE_RULES = [
   { prefix: '/api/weather/conditions', cc: 'public, max-age=300, s-maxage=900' },      // NWS 15m refresh; browser 5m, edge 15m
   { prefix: '/api/weather/alerts',     cc: 'public, max-age=120, s-maxage=300' },      // safety-critical; browser 2m, edge 5m
   { prefix: '/api/weather',            cc: 'public, max-age=120, s-maxage=300' },      // WU data; browser 2m, edge 5m
-  { prefix: '/api/callsign/',          cc: 'public, max-age=3600, s-maxage=86400' },   // immutable lookups; browser 1h, edge 24h
+  { prefix: '/api/callsign',           cc: 'public, max-age=3600, s-maxage=86400' },   // immutable lookups; browser 1h, edge 24h
   { prefix: '/api/voacap',             cc: 'public, max-age=300, s-maxage=1800' },     // heavy computation; browser 5m, edge 30m
 ];
 

--- a/test/smoke/wiring.test.js
+++ b/test/smoke/wiring.test.js
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+// Smoke tests for the Express app wiring. These verify that routers are
+// mounted at the right paths, validation logic is intact, and middleware
+// (cache-control, security, body parser) compose correctly.
+//
+// We deliberately do NOT import spots.js here — it initiates an MQTT
+// connection at module load time, which would leak across tests. Spots
+// routes are exercised by the existing live curl tests instead.
+//
+// We deliberately do NOT exercise routes that depend on upstream HTTP
+// (POTA, NWS, OWM, N2YO, NOAA, etc.) — those would be flaky. Instead we
+// hit endpoints that should respond deterministically: validation
+// failures (400), missing API keys (503), redirects, static content,
+// header behavior.
+
+const { test, describe, before } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+const cacheControlMiddleware = require('../../server/middleware/cache-control');
+const { setupSecurity } = require('../../server/middleware/security');
+const metaRouter = require('../../server/routes/meta');
+const { setupDocs } = require('../../server/routes/meta');
+const callsignRouter = require('../../server/routes/callsign');
+const configRouter = require('../../server/routes/config');
+const weatherRouter = require('../../server/routes/weather');
+const satellitesRouter = require('../../server/routes/satellites');
+const solarRouter = require('../../server/routes/solar');
+
+// Build a test app that mirrors server.js composition (minus spots.js,
+// minus voacap which requires the python bridge, minus startup side effects).
+function buildTestApp() {
+  const app = express();
+  const fakeConfig = {
+    trustProxy: false,
+    isHostedmode: false,
+    helmetOptions: {},
+  };
+  setupSecurity(app, fakeConfig);
+  app.use(metaRouter);
+  app.use(cacheControlMiddleware);
+  setupDocs(app, path.join(__dirname, '..', '..'));
+  app.use('/api', solarRouter);
+  app.use('/api', satellitesRouter);
+  app.use('/api', callsignRouter);
+  app.use('/api', configRouter);
+  app.use('/api/weather', weatherRouter);
+  return app;
+}
+
+let app;
+before(() => { app = buildTestApp(); });
+
+describe('meta router', () => {
+  test('GET /api/health → 200 + { ok: true }', async () => {
+    const res = await request(app).get('/api/health');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(typeof res.body.uptime, 'number');
+  });
+
+  test('GET /api → 302 redirect to /api/docs', async () => {
+    const res = await request(app).get('/api');
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.location, '/api/docs');
+  });
+
+  test('GET /api/docs/ → 200 + Swagger UI HTML', async () => {
+    const res = await request(app).get('/api/docs/');
+    assert.equal(res.status, 200);
+    assert.match(res.text, /HamTab API Documentation/);
+  });
+});
+
+describe('security middleware', () => {
+  test('helmet sets X-Content-Type-Options on /api/health', async () => {
+    const res = await request(app).get('/api/health');
+    assert.equal(res.headers['x-content-type-options'], 'nosniff');
+  });
+
+  test('helmet sets X-Frame-Options on /api/health', async () => {
+    const res = await request(app).get('/api/health');
+    assert.match(res.headers['x-frame-options'] || '', /SAMEORIGIN|DENY/i);
+  });
+
+  test('CSP relaxed on /api/docs path', async () => {
+    const res = await request(app).get('/api/docs/');
+    const csp = res.headers['content-security-policy'] || '';
+    assert.match(csp, /unsafe-inline/);
+  });
+
+  test('rate limiter headers present on /api/* routes', async () => {
+    const res = await request(app).get('/api/weather');
+    // express-rate-limit standardHeaders=true sets RateLimit-* headers
+    assert.ok(res.headers['ratelimit-limit'] || res.headers['x-ratelimit-limit']);
+  });
+});
+
+describe('cache-control middleware', () => {
+  test('sets Cache-Control on a known prefix (no upstream call needed)', async () => {
+    // /api/callsign/ has a Cache-Control rule. Hitting an invalid callsign
+    // returns 400 immediately but should still pick up the header (the
+    // middleware runs before the route handler).
+    const res = await request(app).get('/api/callsign/!!!');
+    assert.equal(res.headers['cache-control'], 'public, max-age=3600, s-maxage=86400');
+  });
+
+  test('does NOT set Cache-Control on POST', async () => {
+    const res = await request(app).post('/api/feedback').send({});
+    // Either no header, or not the GET cache-control rule
+    assert.notEqual(res.headers['cache-control'], 'public, max-age=300, s-maxage=900');
+  });
+});
+
+describe('callsign router', () => {
+  test('GET /api/callsign/INVALID! → 400', async () => {
+    const res = await request(app).get('/api/callsign/INVALID!');
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /Invalid callsign format/);
+  });
+
+  test('GET /api/callsign/<too long> → 400', async () => {
+    const res = await request(app).get('/api/callsign/ABCDEFGHIJK');
+    assert.equal(res.status, 400);
+  });
+});
+
+describe('weather router', () => {
+  test('GET /api/weather without WU_API_KEY → 503', async () => {
+    const prev = process.env.WU_API_KEY;
+    delete process.env.WU_API_KEY;
+    try {
+      const res = await request(app).get('/api/weather');
+      assert.equal(res.status, 503);
+      assert.match(res.body.error, /weather API key/);
+    } finally {
+      if (prev) process.env.WU_API_KEY = prev;
+    }
+  });
+
+  test('GET /api/weather/conditions with invalid lat → 400', async () => {
+    const res = await request(app).get('/api/weather/conditions?lat=999&lon=0');
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /lat|lon/);
+  });
+
+  test('GET /api/weather/conditions outside US coverage → 400', async () => {
+    // London — valid coords but outside NWS coverage
+    const res = await request(app).get('/api/weather/conditions?lat=51.5&lon=-0.1');
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /US/);
+  });
+
+  test('GET /api/weather/clouds without OWM_API_KEY → 503', async () => {
+    const prev = process.env.OWM_API_KEY;
+    delete process.env.OWM_API_KEY;
+    try {
+      const res = await request(app).get('/api/weather/clouds/5/10/12');
+      assert.equal(res.status, 503);
+    } finally {
+      if (prev) process.env.OWM_API_KEY = prev;
+    }
+  });
+
+  test('GET /api/weather/clouds with bad tile coords → 400', async () => {
+    process.env.OWM_API_KEY = 'fake-test-key';
+    try {
+      const res = await request(app).get('/api/weather/clouds/abc/def/ghi');
+      assert.equal(res.status, 400);
+    } finally {
+      delete process.env.OWM_API_KEY;
+    }
+  });
+});
+
+describe('satellites router', () => {
+  test('GET /api/satellites/list without N2YO_API_KEY → 503', async () => {
+    const prev = process.env.N2YO_API_KEY;
+    delete process.env.N2YO_API_KEY;
+    try {
+      const res = await request(app).get('/api/satellites/list');
+      assert.equal(res.status, 503);
+      assert.match(res.body.error, /N2YO/);
+    } finally {
+      if (prev) process.env.N2YO_API_KEY = prev;
+    }
+  });
+});
+
+describe('config router', () => {
+  test('POST /api/config/env from non-private IP without admin token → 403', async () => {
+    // supertest sends from 127.0.0.1 by default which IS private — so this
+    // would normally pass. To exercise the non-private branch we'd need to
+    // simulate a public IP. Instead, verify that with admin token unset,
+    // a private IP is allowed (status != 403).
+    const res = await request(app)
+      .post('/api/config/env')
+      .send({ WU_API_KEY: 'test' });
+    assert.notEqual(res.status, 403);
+  });
+
+  test('POST /api/config/env with invalid body → 400', async () => {
+    const res = await request(app)
+      .post('/api/config/env')
+      .set('Content-Type', 'application/json')
+      .send('"not an object"');
+    assert.equal(res.status, 400);
+  });
+
+  test('POST /api/feedback with no body → 400', async () => {
+    const res = await request(app).post('/api/feedback').send({});
+    assert.equal(res.status, 400);
+  });
+
+  test('POST /api/feedback with honeypot filled → 400', async () => {
+    const res = await request(app)
+      .post('/api/feedback')
+      .send({ feedback: 'Real feedback here', website: 'spam.example.com' });
+    assert.equal(res.status, 400);
+  });
+
+  test('POST /api/feedback with too-short feedback → 400', async () => {
+    const res = await request(app).post('/api/feedback').send({ feedback: 'short' });
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /at least/);
+  });
+});

--- a/test/unit/cache-control.test.js
+++ b/test/unit/cache-control.test.js
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const cacheControl = require('../../server/middleware/cache-control');
+const { CACHE_RULES } = cacheControl;
+
+// Build a fake req/res/next to drive the middleware.
+function run(method, path) {
+  const headers = {};
+  const req = { method, path };
+  const res = { set: (k, v) => { headers[k] = v; } };
+  let nextCalled = false;
+  cacheControl(req, res, () => { nextCalled = true; });
+  return { headers, nextCalled };
+}
+
+describe('cache-control middleware', () => {
+  test('always calls next()', () => {
+    assert.equal(run('GET', '/api/spots').nextCalled, true);
+    assert.equal(run('POST', '/api/feedback').nextCalled, true);
+    assert.equal(run('GET', '/no-rule').nextCalled, true);
+  });
+
+  test('skips non-GET/HEAD requests', () => {
+    const { headers } = run('POST', '/api/spots');
+    assert.equal(headers['Cache-Control'], undefined);
+  });
+
+  test('applies HEAD requests like GET', () => {
+    const { headers } = run('HEAD', '/api/spots');
+    assert.equal(headers['Cache-Control'], 'public, max-age=30, s-maxage=60');
+  });
+
+  test('matches exact prefix', () => {
+    const { headers } = run('GET', '/api/spots');
+    assert.equal(headers['Cache-Control'], 'public, max-age=30, s-maxage=60');
+  });
+
+  test('matches subpath under prefix', () => {
+    const { headers } = run('GET', '/api/spots/dxc');
+    assert.equal(headers['Cache-Control'], 'public, max-age=15, s-maxage=30');
+  });
+
+  test('uses first matching rule (more specific prefixes come first)', () => {
+    // /api/spots/psk/heard is more specific than /api/spots/psk
+    const { headers } = run('GET', '/api/spots/psk/heard');
+    assert.equal(headers['Cache-Control'], 'public, max-age=120, s-maxage=300');
+  });
+
+  test('does not match prefix as a substring of a path segment', () => {
+    // /api/solar should not match /api/solarflare (defensive — we use prefix + "/")
+    const { headers } = run('GET', '/api/solarflare');
+    assert.equal(headers['Cache-Control'], undefined);
+  });
+
+  test('returns no header for unmatched path', () => {
+    const { headers } = run('GET', '/health');
+    assert.equal(headers['Cache-Control'], undefined);
+  });
+
+  test('CACHE_RULES contains all expected route prefixes', () => {
+    const prefixes = new Set(CACHE_RULES.map(r => r.prefix));
+    // Sanity check: a few representative prefixes from each tier
+    assert.ok(prefixes.has('/api/spots'));
+    assert.ok(prefixes.has('/api/solar'));
+    assert.ok(prefixes.has('/api/satellites/positions'));
+    assert.ok(prefixes.has('/api/weather'));
+    assert.ok(prefixes.has('/api/voacap'));
+  });
+
+  test('every CACHE_RULES entry has a valid Cache-Control directive', () => {
+    for (const rule of CACHE_RULES) {
+      assert.match(rule.cc, /^public, max-age=\d+, s-maxage=\d+$/);
+    }
+  });
+});

--- a/test/unit/callsign.test.js
+++ b/test/unit/callsign.test.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isUSCallsign, gridToLatLon } = require('../../server/routes/callsign');
+
+describe('isUSCallsign', () => {
+  test('matches K/N/W single-letter prefixes', () => {
+    assert.equal(isUSCallsign('K1ABC'), true);
+    assert.equal(isUSCallsign('N1ABC'), true);
+    assert.equal(isUSCallsign('W1AW'), true);
+    assert.equal(isUSCallsign('W7XYZ'), true);
+  });
+
+  test('matches K/N/W two-letter prefixes', () => {
+    assert.equal(isUSCallsign('KA1ABC'), true);
+    assert.equal(isUSCallsign('NW7DR'), true);
+    assert.equal(isUSCallsign('WB6QVU'), true);
+  });
+
+  test('matches A[A-L] prefixes', () => {
+    assert.equal(isUSCallsign('AA1A'), true);
+    assert.equal(isUSCallsign('AL7Q'), true);
+    assert.equal(isUSCallsign('AB1XYZ'), true);
+  });
+
+  test('rejects A[M-Z] prefixes (reserved for other countries)', () => {
+    assert.equal(isUSCallsign('AM1ABC'), false);
+    assert.equal(isUSCallsign('AZ1ABC'), false);
+  });
+
+  test('rejects non-US prefixes', () => {
+    assert.equal(isUSCallsign('VE3ABC'), false); // Canada
+    assert.equal(isUSCallsign('G0ABC'), false);  // UK
+    assert.equal(isUSCallsign('JA1ABC'), false); // Japan
+    assert.equal(isUSCallsign('DL1ABC'), false); // Germany
+  });
+
+  test('handles lowercase input (case-insensitive)', () => {
+    assert.equal(isUSCallsign('w1aw'), true);
+    assert.equal(isUSCallsign('k1abc'), true);
+  });
+
+  test('rejects empty/falsy input', () => {
+    assert.equal(isUSCallsign(''), false);
+    assert.equal(isUSCallsign(null), false);
+    assert.equal(isUSCallsign(undefined), false);
+  });
+});
+
+describe('gridToLatLon (Maidenhead grid square)', () => {
+  test('CN87 — Seattle area (4-character grid)', () => {
+    const { lat, lon } = gridToLatLon('CN87');
+    // Field C (lon -160), N (lat 40); square 8 (+16 lon), 7 (+7 lat)
+    // = lon -160 + 16 + 1 = -143... wait
+    // Actually: CN87 → lon = (C-A)*20 + (8-0)*2 + 1 - 180 = 2*20 + 16 + 1 - 180 = -123
+    //          lat = (N-A)*10 + (7-0) + 0.5 - 90 = 13*10 + 7 + 0.5 - 90 = 47.5
+    assert.ok(Math.abs(lat - 47.5) < 0.01);
+    assert.ok(Math.abs(lon - (-123)) < 0.01);
+  });
+
+  test('FN31 — Boston area', () => {
+    const { lat, lon } = gridToLatLon('FN31');
+    // F=5, N=13, 3, 1
+    // lon = 5*20 + 3*2 + 1 - 180 = 100 + 6 + 1 - 180 = -73
+    // lat = 13*10 + 1 + 0.5 - 90 = 130 + 1.5 - 90 = 41.5
+    assert.ok(Math.abs(lat - 41.5) < 0.01);
+    assert.ok(Math.abs(lon - (-73)) < 0.01);
+  });
+
+  test('JJ00 — equator/prime meridian region', () => {
+    const { lat, lon } = gridToLatLon('JJ00');
+    // J=9, J=9, 0, 0
+    // lon = 9*20 + 0 + 1 - 180 = 1
+    // lat = 9*10 + 0 + 0.5 - 90 = 0.5
+    assert.ok(Math.abs(lat - 0.5) < 0.01);
+    assert.ok(Math.abs(lon - 1) < 0.01);
+  });
+
+  test('returns null for too-short input', () => {
+    assert.equal(gridToLatLon(''), null);
+    assert.equal(gridToLatLon('AB'), null);
+    assert.equal(gridToLatLon('ABC'), null);
+  });
+
+  test('returns null for null/undefined', () => {
+    assert.equal(gridToLatLon(null), null);
+    assert.equal(gridToLatLon(undefined), null);
+  });
+
+  test('accepts 6+ character grids (only uses first 4)', () => {
+    const r = gridToLatLon('CN87up');
+    assert.ok(r !== null);
+    assert.ok(typeof r.lat === 'number');
+    assert.ok(typeof r.lon === 'number');
+  });
+});

--- a/test/unit/http-fetch.test.js
+++ b/test/unit/http-fetch.test.js
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isPrivateIP, MAX_REDIRECTS, MAX_RESPONSE_BYTES } = require('../../server/services/http-fetch');
+
+describe('isPrivateIP — IPv4', () => {
+  test('blocks RFC 1918 ranges', () => {
+    assert.equal(isPrivateIP('10.0.0.1'), true);
+    assert.equal(isPrivateIP('10.255.255.255'), true);
+    assert.equal(isPrivateIP('172.16.0.1'), true);
+    assert.equal(isPrivateIP('172.31.255.255'), true);
+    assert.equal(isPrivateIP('192.168.1.1'), true);
+    assert.equal(isPrivateIP('192.168.255.255'), true);
+  });
+
+  test('blocks loopback', () => {
+    assert.equal(isPrivateIP('127.0.0.1'), true);
+    assert.equal(isPrivateIP('127.255.255.254'), true);
+  });
+
+  test('blocks link-local (169.254.0.0/16)', () => {
+    assert.equal(isPrivateIP('169.254.169.254'), true); // AWS metadata
+    assert.equal(isPrivateIP('169.254.0.1'), true);
+  });
+
+  test('blocks 0.0.0.0/8 (current network)', () => {
+    assert.equal(isPrivateIP('0.0.0.0'), true);
+    assert.equal(isPrivateIP('0.1.2.3'), true);
+  });
+
+  test('blocks CGNAT (100.64.0.0/10)', () => {
+    assert.equal(isPrivateIP('100.64.0.1'), true);
+    assert.equal(isPrivateIP('100.127.255.255'), true);
+  });
+
+  test('blocks multicast and reserved', () => {
+    assert.equal(isPrivateIP('224.0.0.1'), true);
+    assert.equal(isPrivateIP('239.255.255.255'), true);
+    assert.equal(isPrivateIP('240.0.0.1'), true);
+    assert.equal(isPrivateIP('255.255.255.255'), true);
+  });
+
+  test('blocks 198.18/15 benchmark range', () => {
+    assert.equal(isPrivateIP('198.18.0.1'), true);
+    assert.equal(isPrivateIP('198.19.255.255'), true);
+  });
+
+  test('does NOT block RFC 1918 boundaries', () => {
+    // 172.15.x.x and 172.32.x.x are public
+    assert.equal(isPrivateIP('172.15.0.1'), false);
+    assert.equal(isPrivateIP('172.32.0.1'), false);
+    // 100.63.x.x and 100.128.x.x are public (CGNAT is 100.64-127)
+    assert.equal(isPrivateIP('100.63.0.1'), false);
+    assert.equal(isPrivateIP('100.128.0.1'), false);
+  });
+
+  test('allows public IPs', () => {
+    assert.equal(isPrivateIP('8.8.8.8'), false);
+    assert.equal(isPrivateIP('1.1.1.1'), false);
+    assert.equal(isPrivateIP('151.101.0.1'), false); // Fastly
+    assert.equal(isPrivateIP('142.250.190.78'), false); // Google
+  });
+});
+
+describe('isPrivateIP — IPv6', () => {
+  test('blocks IPv6 loopback and unspecified', () => {
+    assert.equal(isPrivateIP('::1'), true);
+    assert.equal(isPrivateIP('::'), true);
+  });
+
+  test('blocks IPv6 unique local (fc00::/7)', () => {
+    assert.equal(isPrivateIP('fc00::1'), true);
+    assert.equal(isPrivateIP('fd00::1'), true);
+  });
+
+  test('blocks IPv6 link-local (fe80::/10)', () => {
+    assert.equal(isPrivateIP('fe80::1'), true);
+  });
+
+  test('blocks IPv4-mapped IPv6 representation of private addresses', () => {
+    assert.equal(isPrivateIP('::ffff:10.0.0.1'), true);
+    assert.equal(isPrivateIP('::ffff:127.0.0.1'), true);
+    assert.equal(isPrivateIP('::ffff:169.254.169.254'), true);
+  });
+
+  test('allows IPv4-mapped public addresses', () => {
+    assert.equal(isPrivateIP('::ffff:8.8.8.8'), false);
+  });
+});
+
+describe('http-fetch constants', () => {
+  test('MAX_REDIRECTS is a small positive integer', () => {
+    assert.equal(typeof MAX_REDIRECTS, 'number');
+    assert.ok(MAX_REDIRECTS >= 1 && MAX_REDIRECTS <= 10);
+  });
+
+  test('MAX_RESPONSE_BYTES is reasonable (1KB - 50MB)', () => {
+    assert.equal(typeof MAX_RESPONSE_BYTES, 'number');
+    assert.ok(MAX_RESPONSE_BYTES >= 1024 && MAX_RESPONSE_BYTES <= 50 * 1024 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit + smoke tests to lock in the API modularization extraction (PR #156)
- 61 tests across 13 suites, run with \`npm test\`
- Uses Node's built-in test runner (zero new runtime deps); supertest added as devDependency
- Fix a real bug caught by the harness: the \`/api/callsign/\` rule in cache-control.js had a trailing slash that caused it to never match any subpath

## What's tested

**\`test/unit/\`** — pure functions, no side effects:
- \`cache-control.test.js\` — rule matching, GET/HEAD vs POST, prefix matching, defensive substring check
- \`http-fetch.test.js\` — \`isPrivateIP\` SSRF guard (IPv4 RFC 1918, loopback, link-local, CGNAT, multicast; IPv6 ULA, link-local, IPv4-mapped)
- \`callsign.test.js\` — \`isUSCallsign\` (K/N/W/A[A-L] prefixes, case-insensitive), \`gridToLatLon\` (Maidenhead conversion)

**\`test/smoke/wiring.test.js\`** — supertest against a fresh app composed from the routers (skips spots.js to avoid the MQTT init side effect):
- meta routes (\`/api/health\`, \`/api\` redirect, \`/api/docs/\`)
- security headers (helmet, CSP relaxation on docs, rate limit headers)
- cache-control middleware on a real route
- callsign validation (400 on bad input)
- weather validation (503 missing key, 400 invalid lat/lon, 400 outside US coverage)
- satellites validation (503 missing N2YO key)
- config validation (private IP gate, invalid body, feedback honeypot, length limits)

## Bug found

The harness caught a pre-existing bug: \`/api/callsign/W1AW\` was getting NO Cache-Control header in production because the rule had a trailing slash, and the middleware does \`prefix + '/'\` before \`startsWith\`, producing \`/api/callsign//\` which never matches anything.

**Before:**
\`\`\`
$ curl -sI http://localhost:3000/api/callsign/W1AW | grep -i cache-control
(no header)
\`\`\`

**After:**
\`\`\`
$ curl -sI http://localhost:3000/api/callsign/W1AW | grep -i cache-control
Cache-Control: public, max-age=3600, s-maxage=86400
\`\`\`

Fix is one character: drop the trailing slash from the rule, matching the convention of every other entry.

## Test plan
- [x] \`npm test\` — all 61 tests pass
- [x] Live verification: \`/api/callsign/W1AW\` now returns the expected Cache-Control header
- [x] Other endpoints (solar, spots, weather) still return their correct Cache-Control headers
- [x] Server still starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)