### PR TITLE
Introduce fetch scheduler — behavior-preserving timer migration

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -15653,6 +15653,89 @@ ${beacon.location}`);
   init_widgets();
   init_cross_tab();
   init_feature_flags();
+
+  // src/fetch-scheduler.js
+  init_widgets();
+  init_cross_tab();
+  init_feature_flags();
+
+  // src/fetch-scheduler-policy.js
+  function validateSpec(spec) {
+    if (!spec || typeof spec.id !== "string" || !spec.id) {
+      throw new Error("scheduler: spec.id is required");
+    }
+    if (typeof spec.run !== "function") {
+      throw new Error(`scheduler: ${spec.id}: spec.run must be a function`);
+    }
+    if (typeof spec.intervalMs !== "number" || spec.intervalMs <= 0 || !Number.isFinite(spec.intervalMs)) {
+      throw new Error(`scheduler: ${spec.id}: spec.intervalMs must be a positive finite number`);
+    }
+    if (spec.jitterMs != null && (typeof spec.jitterMs !== "number" || spec.jitterMs < 0)) {
+      throw new Error(`scheduler: ${spec.id}: spec.jitterMs must be a non-negative number`);
+    }
+  }
+  function shouldRun(spec, ctx) {
+    if (spec.requiresVisible !== false && ctx.hidden) return false;
+    if (spec.requiresLeader && !ctx.isLeader) return false;
+    if (spec.featureFlag && !ctx.featureVisible) return false;
+    if (spec.widgetGate) {
+      if (!ctx.widgetVisible && !ctx.widgetGateOrResult) return false;
+    }
+    return true;
+  }
+  function nextDelay(spec, random = Math.random) {
+    if (!spec.jitterMs) return spec.intervalMs;
+    const jitter = Math.floor(random() * spec.jitterMs * 2) - spec.jitterMs;
+    return Math.max(0, spec.intervalMs + jitter);
+  }
+
+  // src/fetch-scheduler.js
+  var jobs = /* @__PURE__ */ new Map();
+  function buildContext(spec) {
+    return {
+      hidden: typeof document !== "undefined" ? document.hidden : false,
+      isLeader: isLeaderTab(),
+      widgetVisible: spec.widgetGate ? isWidgetVisible(spec.widgetGate) : void 0,
+      widgetGateOrResult: spec.widgetGateOr ? !!spec.widgetGateOr() : void 0,
+      featureVisible: spec.featureFlag ? isFeatureVisible(spec.featureFlag) : void 0
+    };
+  }
+  function scheduleNext(id) {
+    const entry = jobs.get(id);
+    if (!entry) return;
+    entry.timer = setTimeout(() => {
+      if (!jobs.has(id)) return;
+      if (shouldRun(entry.spec, buildContext(entry.spec))) {
+        try {
+          entry.spec.run();
+        } catch (err2) {
+          console.error(`[scheduler:${id}]`, err2);
+        }
+      }
+      scheduleNext(id);
+    }, nextDelay(entry.spec));
+  }
+  function register(spec) {
+    validateSpec(spec);
+    if (jobs.has(spec.id)) {
+      throw new Error(`scheduler.register: duplicate id "${spec.id}"`);
+    }
+    jobs.set(spec.id, { spec, timer: null });
+    scheduleNext(spec.id);
+  }
+  function unregister(id) {
+    const entry = jobs.get(id);
+    if (!entry) return false;
+    if (entry.timer) clearTimeout(entry.timer);
+    jobs.delete(id);
+    return true;
+  }
+  function has(id) {
+    return jobs.has(id);
+  }
+
+  // src/refresh.js
+  var AUTO_REFRESH_JOB_ID = "auto-refresh-countdown";
   var dxcSse = null;
   var rbnSse = null;
   function handleSseEvents(source, eventSource, sourceName) {
@@ -15786,27 +15869,35 @@ ${beacon.location}`);
       btn.textContent = "Refresh";
     }
   }
+  function autoRefreshTick() {
+    state_default.countdownSeconds--;
+    if (state_default.countdownSeconds <= 0) {
+      if (isLeaderTab()) {
+        refreshAll();
+      } else {
+        resetCountdown();
+      }
+    }
+    updateCountdownDisplay();
+  }
   function startAutoRefresh() {
     stopAutoRefresh();
     state_default.autoRefreshEnabled = true;
     localStorage.setItem("hamtab_auto_refresh", "true");
     resetCountdown();
-    state_default.countdownTimer = setInterval(() => {
-      if (document.hidden) return;
-      state_default.countdownSeconds--;
-      if (state_default.countdownSeconds <= 0) {
-        if (isLeaderTab()) {
-          refreshAll();
-        } else {
-          resetCountdown();
-        }
-      }
-      updateCountdownDisplay();
-    }, 1e3);
+    register({
+      id: AUTO_REFRESH_JOB_ID,
+      intervalMs: 1e3,
+      run: autoRefreshTick,
+      kind: "render"
+    });
   }
   function stopAutoRefresh() {
     state_default.autoRefreshEnabled = false;
     localStorage.setItem("hamtab_auto_refresh", "false");
+    if (has(AUTO_REFRESH_JOB_ID)) {
+      unregister(AUTO_REFRESH_JOB_ID);
+    }
     if (state_default.countdownTimer) {
       clearInterval(state_default.countdownTimer);
       state_default.countdownTimer = null;
@@ -27187,31 +27278,49 @@ r6IHztIUIH85apHFFGAZkhMtrqHbhc8Er26EILCCHl/7vGS0dfj9WyT1urWcrRbu
   initMap();
   updateGrayLine();
   updateSunMarker();
-  setInterval(() => {
-    if (document.hidden) return;
-    updateGrayLine();
-    updateSunMarker();
-  }, 6e4);
+  register({
+    id: "gray-line",
+    intervalMs: 6e4,
+    run: () => {
+      updateGrayLine();
+      updateSunMarker();
+    },
+    kind: "render"
+  });
   initSatellites();
-  setInterval(() => {
-    if (document.hidden || !isWidgetVisible("widget-satellites") || !isLeaderTab()) return;
-    fetchIssPosition();
-  }, 1e4);
-  setInterval(() => {
-    if (document.hidden || !isWidgetVisible("widget-satellites") || !isLeaderTab()) return;
-    fetchSatellitePositions();
-  }, 1e4);
+  register({
+    id: "iss-position",
+    intervalMs: 1e4,
+    run: fetchIssPosition,
+    requiresLeader: true,
+    widgetGate: "widget-satellites",
+    kind: "fetch"
+  });
+  register({
+    id: "satellite-positions",
+    intervalMs: 1e4,
+    run: fetchSatellitePositions,
+    requiresLeader: true,
+    widgetGate: "widget-satellites",
+    kind: "fetch"
+  });
   updateClocks();
-  setInterval(() => {
-    if (document.hidden) return;
-    updateClocks();
-    updateBigClock();
-    updateAnalogClock();
-  }, 1e3);
-  setInterval(() => {
-    if (document.hidden) return;
-    updateSpotAges();
-  }, 3e4);
+  register({
+    id: "clocks",
+    intervalMs: 1e3,
+    run: () => {
+      updateClocks();
+      updateBigClock();
+      updateAnalogClock();
+    },
+    kind: "render"
+  });
+  register({
+    id: "spot-ages",
+    intervalMs: 3e4,
+    run: updateSpotAges,
+    kind: "render"
+  });
   function safeInit(name, fn) {
     try {
       fn();
@@ -27304,28 +27413,39 @@ r6IHztIUIH85apHFFGAZkhMtrqHbhc8Er26EILCCHl/7vGS0dfj9WyT1urWcrRbu
     const newWidgets = getPendingNewWidgets();
     if (newWidgets.length > 0) showNewWidgetPopup(newWidgets);
   }
-  var PSK_REFRESH_BASE = 5 * 60 * 1e3;
-  var PSK_REFRESH_JITTER = 30 * 1e3;
-  function scheduleLiveSpotsRefresh() {
-    const delay = PSK_REFRESH_BASE + Math.floor(Math.random() * PSK_REFRESH_JITTER * 2) - PSK_REFRESH_JITTER;
-    setTimeout(() => {
-      if (!document.hidden && isWidgetVisible("widget-live-spots") && isLeaderTab()) fetchLiveSpots();
-      scheduleLiveSpotsRefresh();
-    }, delay);
-  }
-  scheduleLiveSpotsRefresh();
-  setInterval(() => {
-    if (document.hidden) return;
-    if (isWidgetVisible("widget-voacap") || state_default.hfPropOverlayBand) renderVoacapMatrix();
-  }, 60 * 1e3);
-  setInterval(() => {
-    if (document.hidden || !isLeaderTab()) return;
-    if (isWidgetVisible("widget-voacap") || state_default.hfPropOverlayBand) fetchVoacapMatrixThrottled();
-  }, 60 * 1e3);
-  setInterval(() => {
-    if (document.hidden || !isWidgetVisible("widget-beacons")) return;
-    updateBeaconMarkers();
-  }, 1e4);
+  register({
+    id: "psk-live-spots",
+    intervalMs: 5 * 60 * 1e3,
+    jitterMs: 30 * 1e3,
+    run: fetchLiveSpots,
+    requiresLeader: true,
+    widgetGate: "widget-live-spots",
+    kind: "fetch"
+  });
+  register({
+    id: "voacap-render",
+    intervalMs: 60 * 1e3,
+    run: renderVoacapMatrix,
+    widgetGate: "widget-voacap",
+    widgetGateOr: () => !!state_default.hfPropOverlayBand,
+    kind: "render"
+  });
+  register({
+    id: "voacap-fetch",
+    intervalMs: 60 * 1e3,
+    run: fetchVoacapMatrixThrottled,
+    requiresLeader: true,
+    widgetGate: "widget-voacap",
+    widgetGateOr: () => !!state_default.hfPropOverlayBand,
+    kind: "fetch"
+  });
+  register({
+    id: "beacon-markers",
+    intervalMs: 1e4,
+    run: updateBeaconMarkers,
+    widgetGate: "widget-beacons",
+    kind: "render"
+  });
   document.addEventListener("visibilitychange", () => {
     if (document.hidden || !state_default.appInitialized) return;
     updateClocks();

--- a/src/fetch-scheduler-policy.js
+++ b/src/fetch-scheduler-policy.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+// Pure scheduler policy helpers — no browser/DOM/state dependencies.
+// Split out from fetch-scheduler.js so the gating + delay logic can be
+// unit-tested in Node without a jsdom shim.
+
+// Validate a job spec. Throws on invalid input.
+export function validateSpec(spec) {
+  if (!spec || typeof spec.id !== 'string' || !spec.id) {
+    throw new Error('scheduler: spec.id is required');
+  }
+  if (typeof spec.run !== 'function') {
+    throw new Error(`scheduler: ${spec.id}: spec.run must be a function`);
+  }
+  if (typeof spec.intervalMs !== 'number' || spec.intervalMs <= 0 || !Number.isFinite(spec.intervalMs)) {
+    throw new Error(`scheduler: ${spec.id}: spec.intervalMs must be a positive finite number`);
+  }
+  if (spec.jitterMs != null && (typeof spec.jitterMs !== 'number' || spec.jitterMs < 0)) {
+    throw new Error(`scheduler: ${spec.id}: spec.jitterMs must be a non-negative number`);
+  }
+}
+
+// Decide whether a job should run given the current gating context.
+// Pure function — takes ctx as a parameter so the caller can inject live
+// values from the browser (or canned values from a test).
+//
+// ctx = {
+//   hidden: boolean,                 // document.hidden
+//   isLeader: boolean,               // isLeaderTab()
+//   widgetVisible: boolean | undefined,  // isWidgetVisible(spec.widgetGate)
+//   widgetGateOrResult: boolean | undefined,  // result of spec.widgetGateOr()
+//   featureVisible: boolean | undefined,  // isFeatureVisible(spec.featureFlag)
+// }
+export function shouldRun(spec, ctx) {
+  if (spec.requiresVisible !== false && ctx.hidden) return false;
+  if (spec.requiresLeader && !ctx.isLeader) return false;
+  if (spec.featureFlag && !ctx.featureVisible) return false;
+  if (spec.widgetGate) {
+    if (!ctx.widgetVisible && !ctx.widgetGateOrResult) return false;
+  }
+  return true;
+}
+
+// Compute the delay (in ms) for the next run of a job.
+// Applies symmetric ± jitter if jitterMs is set. Pure function — uses
+// the supplied random source so tests can pass in deterministic values.
+export function nextDelay(spec, random = Math.random) {
+  if (!spec.jitterMs) return spec.intervalMs;
+  const jitter = Math.floor(random() * spec.jitterMs * 2) - spec.jitterMs;
+  return Math.max(0, spec.intervalMs + jitter);
+}

--- a/src/fetch-scheduler.js
+++ b/src/fetch-scheduler.js
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+// Centralized fetch + render scheduler.
+// Owns periodic work that previously lived as scattered setInterval calls
+// in main.js and refresh.js. Each job is declared with its cadence, jitter,
+// and gating policy (visibility, leader-tab, widget visibility, feature flag).
+//
+// PR 6 scope is behavior-preserving migration: same cadences, same gates.
+// Backoff and freshness metadata land in PR 8; visibility/multi-tab policy
+// consolidation lands in PR 9.
+//
+// Pure policy helpers live in fetch-scheduler-policy.js so they can be
+// unit-tested in Node without a DOM shim.
+
+import { isWidgetVisible } from './widgets.js';
+import { isLeaderTab } from './cross-tab.js';
+import { isFeatureVisible } from './feature-flags.js';
+import { validateSpec, shouldRun, nextDelay } from './fetch-scheduler-policy.js';
+
+// Job spec shape:
+// {
+//   id: string,                  // unique identifier
+//   run: () => any,              // function to invoke (sync or async)
+//   intervalMs: number,          // base cadence in ms
+//   jitterMs?: number,           // ± random jitter in ms (default 0)
+//   requiresLeader?: boolean,    // gate on isLeaderTab() (default false)
+//   requiresVisible?: boolean,   // gate on !document.hidden (default true)
+//   widgetGate?: string,         // gate on isWidgetVisible(widgetGate)
+//   widgetGateOr?: () => boolean, // alternative gate (e.g., overlay band set)
+//   featureFlag?: string,        // gate on isFeatureVisible(featureFlag)
+//   kind?: 'fetch' | 'render',   // metadata for backoff (PR 8) and tooling
+// }
+
+const jobs = new Map(); // id -> { spec, timer }
+
+function buildContext(spec) {
+  return {
+    hidden: typeof document !== 'undefined' ? document.hidden : false,
+    isLeader: isLeaderTab(),
+    widgetVisible: spec.widgetGate ? isWidgetVisible(spec.widgetGate) : undefined,
+    widgetGateOrResult: spec.widgetGateOr ? !!spec.widgetGateOr() : undefined,
+    featureVisible: spec.featureFlag ? isFeatureVisible(spec.featureFlag) : undefined,
+  };
+}
+
+function scheduleNext(id) {
+  const entry = jobs.get(id);
+  if (!entry) return;
+  entry.timer = setTimeout(() => {
+    // Re-check entry — may have been unregistered while timer was pending.
+    if (!jobs.has(id)) return;
+    if (shouldRun(entry.spec, buildContext(entry.spec))) {
+      try {
+        entry.spec.run();
+      } catch (err) {
+        console.error(`[scheduler:${id}]`, err);
+      }
+    }
+    scheduleNext(id);
+  }, nextDelay(entry.spec));
+}
+
+// Register a job and start its timer immediately.
+export function register(spec) {
+  validateSpec(spec);
+  if (jobs.has(spec.id)) {
+    throw new Error(`scheduler.register: duplicate id "${spec.id}"`);
+  }
+  jobs.set(spec.id, { spec, timer: null });
+  scheduleNext(spec.id);
+}
+
+// Stop and remove a job.
+export function unregister(id) {
+  const entry = jobs.get(id);
+  if (!entry) return false;
+  if (entry.timer) clearTimeout(entry.timer);
+  jobs.delete(id);
+  return true;
+}
+
+// Returns true if a job with this id is currently registered.
+export function has(id) {
+  return jobs.has(id);
+}
+
+// List currently registered job ids (for debugging / introspection).
+export function listJobs() {
+  return Array.from(jobs.keys());
+}
+
+// Number of currently registered jobs.
+export function jobCount() {
+  return jobs.size;
+}
+
+// Run a job immediately (without changing its scheduled cadence).
+// Returns false if the job is not registered.
+export function runNow(id) {
+  const entry = jobs.get(id);
+  if (!entry) return false;
+  try {
+    entry.spec.run();
+  } catch (err) {
+    console.error(`[scheduler:${id}]`, err);
+  }
+  return true;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -68,7 +68,8 @@ import { initLogbook, renderLogbookOnMap } from './logbook.js';
 import { initPotaHunter, renderWorkedFilterToggle } from './pota-hunter.js';
 import { initBandScore } from './band-score.js';
 import { isFeatureVisible } from './feature-flags.js';
-import { initCrossTab, isLeaderTab } from './cross-tab.js';
+import { initCrossTab } from './cross-tab.js';
+import { register as registerJob } from './fetch-scheduler.js';
 
 // Initialize map
 initMap();
@@ -76,17 +77,46 @@ initMap();
 // Initialize gray line + sun marker.
 updateGrayLine();
 updateSunMarker();
-setInterval(() => { if (document.hidden) return; updateGrayLine(); updateSunMarker(); }, 60000); // 60 s — gray line + sun marker refresh
+registerJob({
+  id: 'gray-line',
+  intervalMs: 60_000,
+  run: () => { updateGrayLine(); updateSunMarker(); },
+  kind: 'render',
+});
 
 // Satellite tracking (multi-satellite via N2YO)
 initSatellites();
-setInterval(() => { if (document.hidden || !isWidgetVisible('widget-satellites') || !isLeaderTab()) return; fetchIssPosition(); }, 10000); // 10 s — ISS position refresh (free, no API key)
-setInterval(() => { if (document.hidden || !isWidgetVisible('widget-satellites') || !isLeaderTab()) return; fetchSatellitePositions(); }, 10000); // 10 s — other satellite position refresh (N2YO)
+registerJob({
+  id: 'iss-position',
+  intervalMs: 10_000,
+  run: fetchIssPosition,
+  requiresLeader: true,
+  widgetGate: 'widget-satellites',
+  kind: 'fetch',
+});
+registerJob({
+  id: 'satellite-positions',
+  intervalMs: 10_000,
+  run: fetchSatellitePositions,
+  requiresLeader: true,
+  widgetGate: 'widget-satellites',
+  kind: 'fetch',
+});
 
 // Clocks — purely visual, skip entirely when hidden.
 updateClocks();
-setInterval(() => { if (document.hidden) return; updateClocks(); updateBigClock(); updateAnalogClock(); }, 1000);
-setInterval(() => { if (document.hidden) return; updateSpotAges(); }, 30000); // 30 s — patch age cells in place (avoids full table rebuild)
+registerJob({
+  id: 'clocks',
+  intervalMs: 1000,
+  run: () => { updateClocks(); updateBigClock(); updateAnalogClock(); },
+  kind: 'render',
+});
+registerJob({
+  id: 'spot-ages',
+  intervalMs: 30_000,
+  run: updateSpotAges,
+  kind: 'render',
+});
 
 // --- Safe widget init — isolates crashes so one widget can't break the rest ---
 function safeInit(name, fn) {
@@ -191,25 +221,45 @@ function initApp() {
   if (newWidgets.length > 0) showNewWidgetPopup(newWidgets);
 }
 
-// Live Spots refresh (5 min + jitter — PSKReporter rate limit) — leader tab only.
+// Live Spots refresh (5 min ± 30s jitter — PSKReporter rate limit) — leader tab only.
 // Jitter prevents synchronized bursts when multiple instances share the same server.
-const PSK_REFRESH_BASE = 5 * 60 * 1000;   // 5 min base
-const PSK_REFRESH_JITTER = 30 * 1000;     // ±30s jitter
-function scheduleLiveSpotsRefresh() {
-  const delay = PSK_REFRESH_BASE + Math.floor(Math.random() * PSK_REFRESH_JITTER * 2) - PSK_REFRESH_JITTER;
-  setTimeout(() => {
-    if (!document.hidden && isWidgetVisible('widget-live-spots') && isLeaderTab()) fetchLiveSpots();
-    scheduleLiveSpotsRefresh();
-  }, delay);
-}
-scheduleLiveSpotsRefresh();
+registerJob({
+  id: 'psk-live-spots',
+  intervalMs: 5 * 60 * 1000,
+  jitterMs: 30 * 1000,
+  run: fetchLiveSpots,
+  requiresLeader: true,
+  widgetGate: 'widget-live-spots',
+  kind: 'fetch',
+});
 
 // VOACAP matrix refresh — render every minute (for hour transitions), fetch leader-only.
-setInterval(() => { if (document.hidden) return; if (isWidgetVisible('widget-voacap') || state.hfPropOverlayBand) renderVoacapMatrix(); }, 60 * 1000);
-setInterval(() => { if (document.hidden || !isLeaderTab()) return; if (isWidgetVisible('widget-voacap') || state.hfPropOverlayBand) fetchVoacapMatrixThrottled(); }, 60 * 1000);
+registerJob({
+  id: 'voacap-render',
+  intervalMs: 60 * 1000,
+  run: renderVoacapMatrix,
+  widgetGate: 'widget-voacap',
+  widgetGateOr: () => !!state.hfPropOverlayBand,
+  kind: 'render',
+});
+registerJob({
+  id: 'voacap-fetch',
+  intervalMs: 60 * 1000,
+  run: fetchVoacapMatrixThrottled,
+  requiresLeader: true,
+  widgetGate: 'widget-voacap',
+  widgetGateOr: () => !!state.hfPropOverlayBand,
+  kind: 'fetch',
+});
 
 // Beacon map markers — refresh every 10s (same as beacon rotation)
-setInterval(() => { if (document.hidden || !isWidgetVisible('widget-beacons')) return; updateBeaconMarkers(); }, 10000);
+registerJob({
+  id: 'beacon-markers',
+  intervalMs: 10_000,
+  run: updateBeaconMarkers,
+  widgetGate: 'widget-beacons',
+  kind: 'render',
+});
 
 // DE/DX Info refresh — timer managed internally by dedx-info.js (1s for live clocks)
 

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -16,6 +16,9 @@ import { fetchContests } from './contests.js';
 import { isWidgetVisible } from './widgets.js';
 import { isLeaderTab } from './cross-tab.js';
 import { isFeatureVisible } from './feature-flags.js';
+import { register as registerJob, unregister as unregisterJob, has as hasJob } from './fetch-scheduler.js';
+
+const AUTO_REFRESH_JOB_ID = 'auto-refresh-countdown';
 
 // --- DXC/RBN SSE Live Connections ---
 
@@ -169,30 +172,43 @@ function updateCountdownDisplay() {
   }
 }
 
+// Auto-refresh countdown — ticks once per second when visible. Followers
+// tick the countdown for display parity but defer the actual refreshAll()
+// to the leader tab. The leader-tab gate stays inside the run function
+// (not on the scheduler job) so that follower tabs still update the
+// visible "Refresh (Ns)" button.
+function autoRefreshTick() {
+  state.countdownSeconds--;
+  if (state.countdownSeconds <= 0) {
+    if (isLeaderTab()) {
+      refreshAll();
+    } else {
+      resetCountdown(); // restart countdown without fetching
+    }
+  }
+  updateCountdownDisplay();
+}
+
 export function startAutoRefresh() {
   stopAutoRefresh();
   state.autoRefreshEnabled = true;
   localStorage.setItem('hamtab_auto_refresh', 'true');
   resetCountdown();
-  state.countdownTimer = setInterval(() => {
-    if (document.hidden) return; // skip countdown ticks while hidden
-    state.countdownSeconds--;
-    if (state.countdownSeconds <= 0) {
-      // Follower tabs skip auto-refresh — leader/solo tabs fetch for everyone.
-      // Followers still show countdown and catch up on manual refresh or tab focus.
-      if (isLeaderTab()) {
-        refreshAll();
-      } else {
-        resetCountdown(); // restart countdown without fetching
-      }
-    }
-    updateCountdownDisplay();
-  }, 1000);
+  registerJob({
+    id: AUTO_REFRESH_JOB_ID,
+    intervalMs: 1000,
+    run: autoRefreshTick,
+    kind: 'render',
+  });
 }
 
 export function stopAutoRefresh() {
   state.autoRefreshEnabled = false;
   localStorage.setItem('hamtab_auto_refresh', 'false');
+  if (hasJob(AUTO_REFRESH_JOB_ID)) {
+    unregisterJob(AUTO_REFRESH_JOB_ID);
+  }
+  // Clean up legacy state.countdownTimer in case it lingers across hot reloads.
   if (state.countdownTimer) {
     clearInterval(state.countdownTimer);
     state.countdownTimer = null;

--- a/test/unit/fetch-scheduler-policy.test.mjs
+++ b/test/unit/fetch-scheduler-policy.test.mjs
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validateSpec, shouldRun, nextDelay } from '../../src/fetch-scheduler-policy.js';
+
+const noop = () => {};
+const validSpec = { id: 'test', run: noop, intervalMs: 1000 };
+
+describe('validateSpec', () => {
+  test('accepts a minimal valid spec', () => {
+    assert.doesNotThrow(() => validateSpec(validSpec));
+  });
+
+  test('accepts a fully populated spec', () => {
+    assert.doesNotThrow(() => validateSpec({
+      id: 'full',
+      run: noop,
+      intervalMs: 60_000,
+      jitterMs: 5_000,
+      requiresLeader: true,
+      requiresVisible: false,
+      widgetGate: 'widget-foo',
+      widgetGateOr: () => false,
+      featureFlag: 'feature-foo',
+      kind: 'fetch',
+    }));
+  });
+
+  test('rejects missing id', () => {
+    assert.throws(() => validateSpec({ run: noop, intervalMs: 1000 }), /spec\.id/);
+    assert.throws(() => validateSpec({ id: '', run: noop, intervalMs: 1000 }), /spec\.id/);
+  });
+
+  test('rejects non-function run', () => {
+    assert.throws(() => validateSpec({ id: 'x', run: 'not a fn', intervalMs: 1000 }), /spec\.run/);
+  });
+
+  test('rejects missing/invalid intervalMs', () => {
+    assert.throws(() => validateSpec({ id: 'x', run: noop }), /intervalMs/);
+    assert.throws(() => validateSpec({ id: 'x', run: noop, intervalMs: 0 }), /intervalMs/);
+    assert.throws(() => validateSpec({ id: 'x', run: noop, intervalMs: -1 }), /intervalMs/);
+    assert.throws(() => validateSpec({ id: 'x', run: noop, intervalMs: Infinity }), /intervalMs/);
+  });
+
+  test('rejects negative jitterMs', () => {
+    assert.throws(() => validateSpec({ id: 'x', run: noop, intervalMs: 1000, jitterMs: -1 }), /jitterMs/);
+  });
+
+  test('accepts jitterMs of 0', () => {
+    assert.doesNotThrow(() => validateSpec({ id: 'x', run: noop, intervalMs: 1000, jitterMs: 0 }));
+  });
+});
+
+describe('shouldRun — visibility gate', () => {
+  test('runs when visible (default requiresVisible=true)', () => {
+    assert.equal(shouldRun({ ...validSpec }, { hidden: false, isLeader: true }), true);
+  });
+
+  test('skips when hidden (default requiresVisible=true)', () => {
+    assert.equal(shouldRun({ ...validSpec }, { hidden: true, isLeader: true }), false);
+  });
+
+  test('runs when hidden if requiresVisible is explicitly false', () => {
+    assert.equal(shouldRun({ ...validSpec, requiresVisible: false }, { hidden: true, isLeader: true }), true);
+  });
+});
+
+describe('shouldRun — leader gate', () => {
+  test('runs when leader and requiresLeader=true', () => {
+    assert.equal(shouldRun({ ...validSpec, requiresLeader: true }, { hidden: false, isLeader: true }), true);
+  });
+
+  test('skips when follower and requiresLeader=true', () => {
+    assert.equal(shouldRun({ ...validSpec, requiresLeader: true }, { hidden: false, isLeader: false }), false);
+  });
+
+  test('runs when follower and requiresLeader is unset', () => {
+    assert.equal(shouldRun({ ...validSpec }, { hidden: false, isLeader: false }), true);
+  });
+});
+
+describe('shouldRun — widget gate', () => {
+  const spec = { ...validSpec, widgetGate: 'widget-foo' };
+
+  test('runs when widget visible', () => {
+    assert.equal(shouldRun(spec, { hidden: false, isLeader: true, widgetVisible: true }), true);
+  });
+
+  test('skips when widget not visible', () => {
+    assert.equal(shouldRun(spec, { hidden: false, isLeader: true, widgetVisible: false }), false);
+  });
+
+  test('runs when widget not visible but widgetGateOr returns true', () => {
+    assert.equal(
+      shouldRun(spec, { hidden: false, isLeader: true, widgetVisible: false, widgetGateOrResult: true }),
+      true
+    );
+  });
+
+  test('skips when both widgetVisible and widgetGateOr are false', () => {
+    assert.equal(
+      shouldRun(spec, { hidden: false, isLeader: true, widgetVisible: false, widgetGateOrResult: false }),
+      false
+    );
+  });
+});
+
+describe('shouldRun — feature flag gate', () => {
+  const spec = { ...validSpec, featureFlag: 'my-feature' };
+
+  test('runs when feature visible', () => {
+    assert.equal(shouldRun(spec, { hidden: false, isLeader: true, featureVisible: true }), true);
+  });
+
+  test('skips when feature not visible', () => {
+    assert.equal(shouldRun(spec, { hidden: false, isLeader: true, featureVisible: false }), false);
+  });
+});
+
+describe('shouldRun — combined gates', () => {
+  test('all gates must pass', () => {
+    const spec = {
+      ...validSpec,
+      requiresLeader: true,
+      widgetGate: 'widget-foo',
+      featureFlag: 'feat',
+    };
+    const allOk = { hidden: false, isLeader: true, widgetVisible: true, featureVisible: true };
+    assert.equal(shouldRun(spec, allOk), true);
+    assert.equal(shouldRun(spec, { ...allOk, hidden: true }), false);
+    assert.equal(shouldRun(spec, { ...allOk, isLeader: false }), false);
+    assert.equal(shouldRun(spec, { ...allOk, widgetVisible: false }), false);
+    assert.equal(shouldRun(spec, { ...allOk, featureVisible: false }), false);
+  });
+});
+
+describe('nextDelay', () => {
+  test('returns intervalMs exactly when no jitter', () => {
+    assert.equal(nextDelay({ ...validSpec, intervalMs: 1000 }), 1000);
+    assert.equal(nextDelay({ ...validSpec, intervalMs: 60_000 }), 60_000);
+  });
+
+  test('jitter ranges symmetrically around intervalMs', () => {
+    const spec = { ...validSpec, intervalMs: 1000, jitterMs: 100 };
+    // random()=0   → intervalMs - jitterMs = 900
+    assert.equal(nextDelay(spec, () => 0), 900);
+    // random()=0.5 → intervalMs (centered)
+    assert.equal(nextDelay(spec, () => 0.5), 1000);
+    // random()=0.999 → intervalMs + jitterMs ≈ 1099
+    assert.ok(nextDelay(spec, () => 0.999) >= 1099);
+  });
+
+  test('clamps to non-negative when jitter exceeds intervalMs', () => {
+    const spec = { ...validSpec, intervalMs: 50, jitterMs: 200 };
+    assert.equal(nextDelay(spec, () => 0), 0); // 50 - 200 = -150 → clamped to 0
+  });
+
+  test('many random samples stay in [intervalMs - jitterMs, intervalMs + jitterMs]', () => {
+    const spec = { ...validSpec, intervalMs: 5000, jitterMs: 500 };
+    for (let i = 0; i < 100; i++) {
+      const d = nextDelay(spec);
+      assert.ok(d >= 4500 && d <= 5500, `delay ${d} out of range`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
PR 6 of the API modularization plan. Introduces \`src/fetch-scheduler.js\` with a declarative job model and migrates all existing \`setInterval\`/\`setTimeout\` sites in \`main.js\` and \`refresh.js\` to it. **Behavior-preserving — same cadences, same gates, no policy changes.**

## Job model

\`\`\`js
register({
  id: 'string',
  run: () => any,
  intervalMs: number,
  jitterMs?: number,
  requiresLeader?: boolean,
  requiresVisible?: boolean,    // default true
  widgetGate?: string,          // e.g. 'widget-satellites'
  widgetGateOr?: () => boolean, // e.g. () => !!state.hfPropOverlayBand
  featureFlag?: string,
  kind?: 'fetch' | 'render',
});
\`\`\`

## Migrated jobs (10 total)

| Job | Cadence | Gates | Kind |
|---|---|---|---|
| \`gray-line\` | 60s | visible | render |
| \`iss-position\` | 10s | visible + leader + widget-satellites | fetch |
| \`satellite-positions\` | 10s | visible + leader + widget-satellites | fetch |
| \`clocks\` | 1s | visible | render |
| \`spot-ages\` | 30s | visible | render |
| \`psk-live-spots\` | 5min ± 30s jitter | visible + leader + widget-live-spots | fetch |
| \`voacap-render\` | 60s | visible + (widget-voacap OR overlay band) | render |
| \`voacap-fetch\` | 60s | visible + leader + (widget-voacap OR overlay band) | fetch |
| \`beacon-markers\` | 10s | visible + widget-beacons | render |
| \`auto-refresh-countdown\` | 1s | visible | render |

The auto-refresh countdown is a special case — followers still tick the visible \"Refresh (Ns)\" button for display parity, so the leader-tab gate stays inside the run function instead of on the scheduler job.

## Architecture

- \`src/fetch-scheduler.js\` — runtime (browser-only, imports state/widgets/cross-tab/feature-flags)
- \`src/fetch-scheduler-policy.js\` — pure policy helpers (\`validateSpec\`, \`shouldRun\`, \`nextDelay\`) — no DOM/state dependencies, fully unit-testable in Node

The split lets us cover the gating + jitter math in unit tests without a jsdom shim.

## Test plan
- [x] Build succeeds (\`npm run build\`)
- [x] All 10 job ids present in the bundled \`public/app.js\`
- [x] Bundle loads past scheduler imports under a Node DOM stub
- [x] All 85 tests pass (24 new policy unit tests covering spec validation, all gating combinations, jitter math, clamping)
- [x] **Live browser smoke**: clocks tick (1s job), spot ages update (30s job), gray-line shifts on map (60s job) — covers all three cadence scales and proves the scheduler loop is alive end-to-end

## Out of scope (follow-ups)
- \`src/update.js:35\` has its own \`setInterval(checkUpdateStatus, 30000)\` that wasn't in the plan's migration list. Worth migrating in a follow-up for \"one scheduler authority,\" but not blocking PR 6.
- Backoff + freshness metadata → PR 8
- Visibility/multi-tab consolidation (move \`document.hidden\`/\`isLeaderTab\` policy out of the scheduler's own internal checks) → PR 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)