### PR TITLE
Refactor source fetching around declarative job specs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -15799,54 +15799,82 @@ ${beacon.location}`);
   function isRbnSseActive() {
     return rbnSse !== null;
   }
-  async function fetchSourceData(source) {
-    const def = SOURCE_DEFS[source];
-    if (!def) return;
-    if (source === "dxc" && isDxcSseActive()) return;
-    if (source === "rbn" && isRbnSseActive()) return;
+  var SOURCE_JOBS = [
+    {
+      id: "source-pota",
+      source: "pota",
+      cacheable: false,
+      transform: (data) => (Array.isArray(data) ? data : []).map((s) => {
+        if (!s.callsign && s.activator) s.callsign = s.activator;
+        return s;
+      })
+    },
+    { id: "source-sota", source: "sota", cacheable: false },
+    {
+      id: "source-dxc",
+      source: "dxc",
+      cacheable: false,
+      shortCircuit: () => isDxcSseActive()
+    },
+    { id: "source-wwff", source: "wwff", cacheable: false },
+    { id: "source-psk", source: "psk", cacheable: true },
+    { id: "source-wspr", source: "wspr", cacheable: true },
+    {
+      id: "source-rbn",
+      source: "rbn",
+      cacheable: false,
+      featureFlag: "rbn_source",
+      shortCircuit: () => isRbnSseActive()
+    }
+  ];
+  async function fetchSourceRaw(job) {
+    const def = SOURCE_DEFS[job.source];
+    if (!def) throw new Error(`Unknown source: ${job.source}`);
+    if (job.shortCircuit && job.shortCircuit()) return null;
+    const url = job.cacheable ? def.endpoint : def.endpoint + (def.endpoint.includes("?") ? "&" : "?") + "_t=" + Date.now();
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    return resp.json();
+  }
+  function applySourceData(job, rawData) {
+    const transformed = job.transform ? job.transform(rawData) : rawData;
+    state_default.sourceData[job.source] = Array.isArray(transformed) ? transformed : [];
+    if (job.source === "wspr" && state_default.mapOverlays.wsprHeatmap) {
+      clearTimeout(state_default.wsprHeatmapRenderTimer);
+      const { renderWsprHeatmapCanvas: renderWsprHeatmapCanvas2 } = (init_wspr_heatmap(), __toCommonJS(wspr_heatmap_exports));
+      state_default.wsprHeatmapRenderTimer = setTimeout(
+        () => renderWsprHeatmapCanvas2(state_default.wsprHeatmapBand),
+        200
+      );
+    }
+    if (job.source === state_default.currentSource) {
+      applyFilter();
+      renderSpots();
+      renderMarkers();
+      updateBandFilterButtons();
+      updateModeFilterButtons();
+      updateCountryFilter();
+      updateStateFilter();
+      updateGridFilter();
+      updateContinentFilter();
+    }
+  }
+  async function runSourceJob(job) {
+    if (job.featureFlag && !isFeatureVisible(job.featureFlag)) return;
     try {
-      const cacheable = source === "psk" || source === "wspr";
-      const url = cacheable ? def.endpoint : def.endpoint + (def.endpoint.includes("?") ? "&" : "?") + "_t=" + Date.now();
-      const resp = await fetch(url);
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-      let data = await resp.json();
-      if (source === "pota") {
-        data = (Array.isArray(data) ? data : []).map((s) => {
-          if (!s.callsign && s.activator) s.callsign = s.activator;
-          return s;
-        });
-      }
-      state_default.sourceData[source] = Array.isArray(data) ? data : [];
-      if (source === "wspr" && state_default.mapOverlays.wsprHeatmap) {
-        clearTimeout(state_default.wsprHeatmapRenderTimer);
-        const { renderWsprHeatmapCanvas: renderWsprHeatmapCanvas2 } = (init_wspr_heatmap(), __toCommonJS(wspr_heatmap_exports));
-        state_default.wsprHeatmapRenderTimer = setTimeout(() => renderWsprHeatmapCanvas2(state_default.wsprHeatmapBand), 200);
-      }
-      if (source === state_default.currentSource) {
-        applyFilter();
-        renderSpots();
-        renderMarkers();
-        updateBandFilterButtons();
-        updateModeFilterButtons();
-        updateCountryFilter();
-        updateStateFilter();
-        updateGridFilter();
-        updateContinentFilter();
-      }
+      const data = await fetchSourceRaw(job);
+      if (data === null) return;
+      applySourceData(job, data);
     } catch (err2) {
-      console.error(`Failed to fetch ${source} spots:`, err2);
+      console.error(`Failed to fetch ${job.source} spots:`, err2);
     }
   }
   function refreshAll() {
     const btn = $("refreshBtn");
     if (btn) btn.textContent = "Refreshing...";
-    fetchSourceData("pota");
-    fetchSourceData("sota");
-    fetchSourceData("dxc");
-    fetchSourceData("wwff");
-    fetchSourceData("psk");
-    fetchSourceData("wspr");
-    if (isFeatureVisible("rbn_source")) fetchSourceData("rbn");
+    for (const job of SOURCE_JOBS) {
+      runSourceJob(job);
+    }
     if (isWidgetVisible("widget-solar") || isWidgetVisible("widget-propagation") || isWidgetVisible("widget-voacap")) fetchSolar();
     if (isWidgetVisible("widget-lunar")) fetchLunar();
     fetchPropagation();

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -93,60 +93,146 @@ export function disconnectRbnSse() {
 export function isDxcSseActive() { return dxcSse !== null; }
 export function isRbnSseActive() { return rbnSse !== null; }
 
-export async function fetchSourceData(source) {
-  const def = SOURCE_DEFS[source];
-  if (!def) return;
-  // Skip HTTP polling when SSE stream is active for this source.
-  if (source === 'dxc' && isDxcSseActive()) return;
-  if (source === 'rbn' && isRbnSseActive()) return;
-  try {
-    // PSK and WSPR use server-side caching with appropriate TTLs — skip _t to allow edge cache hits.
-    const cacheable = source === 'psk' || source === 'wspr';
-    const url = cacheable ? def.endpoint : def.endpoint + (def.endpoint.includes('?') ? '&' : '?') + '_t=' + Date.now();
-    const resp = await fetch(url);
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    let data = await resp.json();
-    if (source === 'pota') {
-      data = (Array.isArray(data) ? data : []).map(s => {
-        if (!s.callsign && s.activator) s.callsign = s.activator;
-        return s;
-      });
-    }
-    state.sourceData[source] = Array.isArray(data) ? data : [];
-    // Re-render WSPR heatmap when fresh WSPR data arrives.
-    if (source === 'wspr' && state.mapOverlays.wsprHeatmap) {
-      clearTimeout(state.wsprHeatmapRenderTimer);
-      const { renderWsprHeatmapCanvas } = require('./wspr-heatmap.js');
-      state.wsprHeatmapRenderTimer = setTimeout(() => renderWsprHeatmapCanvas(state.wsprHeatmapBand), 200);
-    }
-    if (source === state.currentSource) {
-      applyFilter();
-      renderSpots();
-      renderMarkers();
-      updateBandFilterButtons();
-      updateModeFilterButtons();
-      updateCountryFilter();
-      updateStateFilter();
-      updateGridFilter();
-      updateContinentFilter();
-    }
-  } catch (err) {
-    console.error(`Failed to fetch ${source} spots:`, err);
+// --- Source job descriptors ---
+//
+// Each spot source is described declaratively. The list replaces the
+// hardcoded fan-out in refreshAll(). Adding a new source = appending an
+// entry here, no orchestrator changes required.
+//
+// Fields:
+//   id          — scheduler-compatible job id (unique)
+//   source      — key into SOURCE_DEFS / state.sourceData
+//   featureFlag — optional feature flag gate
+//   shortCircuit — optional () => boolean. When it returns true, the fetch
+//                  is skipped (used to defer to an active SSE stream).
+//   transform   — optional (data) => data, applied to the raw response
+//                 before storing in state.sourceData
+//   cacheable   — true if the endpoint is server-side cached and we can
+//                 rely on edge cache hits (skip the _t cache-buster).
+//
+// Each entry has the same SHAPE as a fetch-scheduler job spec (id +
+// gating fields), so PR 8 can register them with the scheduler when
+// per-source backoff and freshness metadata are added.
+
+const SOURCE_JOBS = [
+  { id: 'source-pota', source: 'pota', cacheable: false,
+    transform: (data) => (Array.isArray(data) ? data : []).map(s => {
+      if (!s.callsign && s.activator) s.callsign = s.activator;
+      return s;
+    }),
+  },
+  { id: 'source-sota', source: 'sota', cacheable: false },
+  { id: 'source-dxc',  source: 'dxc',  cacheable: false,
+    shortCircuit: () => isDxcSseActive(),
+  },
+  { id: 'source-wwff', source: 'wwff', cacheable: false },
+  { id: 'source-psk',  source: 'psk',  cacheable: true },
+  { id: 'source-wspr', source: 'wspr', cacheable: true },
+  { id: 'source-rbn',  source: 'rbn',  cacheable: false,
+    featureFlag: 'rbn_source',
+    shortCircuit: () => isRbnSseActive(),
+  },
+];
+
+// --- Layer 1: source descriptor lookup ---
+
+export function getSourceJob(source) {
+  return SOURCE_JOBS.find(j => j.source === source) || null;
+}
+
+export function listSourceJobs() {
+  return SOURCE_JOBS.slice();
+}
+
+// --- Layer 2: fetch execution ---
+// Pure: builds the URL, hits the endpoint, returns parsed JSON.
+// No state mutation, no DOM, no rendering. Returns null if the source
+// short-circuits (e.g., SSE stream active).
+
+async function fetchSourceRaw(job) {
+  const def = SOURCE_DEFS[job.source];
+  if (!def) throw new Error(`Unknown source: ${job.source}`);
+  if (job.shortCircuit && job.shortCircuit()) return null;
+  const url = job.cacheable
+    ? def.endpoint
+    : def.endpoint + (def.endpoint.includes('?') ? '&' : '?') + '_t=' + Date.now();
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+// --- Layer 3: UI/state application ---
+// Takes already-parsed data and updates state.sourceData + re-renders if
+// this source is currently visible. Pure-ish: only side effects are state
+// mutation and DOM updates via the existing render functions.
+
+function applySourceData(job, rawData) {
+  const transformed = job.transform ? job.transform(rawData) : rawData;
+  state.sourceData[job.source] = Array.isArray(transformed) ? transformed : [];
+
+  // Re-render WSPR heatmap when fresh WSPR data arrives.
+  if (job.source === 'wspr' && state.mapOverlays.wsprHeatmap) {
+    clearTimeout(state.wsprHeatmapRenderTimer);
+    const { renderWsprHeatmapCanvas } = require('./wspr-heatmap.js');
+    state.wsprHeatmapRenderTimer = setTimeout(
+      () => renderWsprHeatmapCanvas(state.wsprHeatmapBand),
+      200
+    );
+  }
+
+  if (job.source === state.currentSource) {
+    applyFilter();
+    renderSpots();
+    renderMarkers();
+    updateBandFilterButtons();
+    updateModeFilterButtons();
+    updateCountryFilter();
+    updateStateFilter();
+    updateGridFilter();
+    updateContinentFilter();
   }
 }
+
+// --- Job runner: orchestrates fetch + apply with feature-flag gate ---
+
+async function runSourceJob(job) {
+  if (job.featureFlag && !isFeatureVisible(job.featureFlag)) return;
+  try {
+    const data = await fetchSourceRaw(job);
+    if (data === null) return; // short-circuited
+    applySourceData(job, data);
+  } catch (err) {
+    console.error(`Failed to fetch ${job.source} spots:`, err);
+  }
+}
+
+// Backward-compatible API: callers (e.g., source.js when switching tabs)
+// invoke fetchSourceData(source) by name. Looks up the descriptor and
+// runs the same code path as the orchestrator.
+export async function fetchSourceData(source) {
+  const job = getSourceJob(source);
+  if (!job) return;
+  return runSourceJob(job);
+}
+
+// --- Manual override / orchestrator ---
+// refreshAll iterates the registered source jobs (no more hardcoded
+// fan-out) and also kicks the auxiliary widget fetches that aren't yet
+// modeled as source jobs. Same trigger semantics as before — fired by
+// the auto-refresh countdown and the manual refresh button.
 
 export function refreshAll() {
   // Brief "Refreshing..." feedback
   const btn = $('refreshBtn');
   if (btn) btn.textContent = 'Refreshing...';
 
-  fetchSourceData('pota');
-  fetchSourceData('sota');
-  fetchSourceData('dxc');
-  fetchSourceData('wwff');
-  fetchSourceData('psk');
-  fetchSourceData('wspr');
-  if (isFeatureVisible('rbn_source')) fetchSourceData('rbn');
+  // Fan out to all registered source jobs.
+  for (const job of SOURCE_JOBS) {
+    runSourceJob(job);
+  }
+
+  // Auxiliary widget fetches — not yet modeled as source jobs because
+  // they don't share the SOURCE_DEFS shape and have widget-specific gates.
   if (isWidgetVisible('widget-solar') || isWidgetVisible('widget-propagation') || isWidgetVisible('widget-voacap')) fetchSolar();
   if (isWidgetVisible('widget-lunar')) fetchLunar();
   fetchPropagation(); // map overlay, always useful


### PR DESCRIPTION
## Summary
PR 7 of the API modularization plan. Splits \`fetchSourceData\` into three layers and replaces the hardcoded fan-out in \`refreshAll()\` with iteration over a declarative \`SOURCE_JOBS\` list. **Behavior-preserving** — same fetches, same triggers, same UI updates.

## The 3-layer split

| Layer | Function | Responsibility |
|---|---|---|
| Source descriptor | \`SOURCE_JOBS\` (data) | Static config: id, source name, cacheable flag, featureFlag, shortCircuit, transform |
| Fetch execution | \`fetchSourceRaw(job)\` | Pure HTTP — builds URL, fetches, returns parsed JSON or \`null\` when short-circuited. No state, no rendering |
| UI/state application | \`applySourceData(job, data)\` | Updates \`state.sourceData\`, re-renders if the source is currently visible |

## Source job descriptors

Each source is now declared as data:

\`\`\`js
const SOURCE_JOBS = [
  { id: 'source-pota', source: 'pota', cacheable: false,
    transform: (data) => /* activator → callsign normalization */ },
  { id: 'source-sota', source: 'sota', cacheable: false },
  { id: 'source-dxc',  source: 'dxc',  cacheable: false,
    shortCircuit: () => isDxcSseActive() },
  { id: 'source-wwff', source: 'wwff', cacheable: false },
  { id: 'source-psk',  source: 'psk',  cacheable: true },
  { id: 'source-wspr', source: 'wspr', cacheable: true },
  { id: 'source-rbn',  source: 'rbn',  cacheable: false,
    featureFlag: 'rbn_source',
    shortCircuit: () => isRbnSseActive() },
];
\`\`\`

The shape mirrors a \`fetch-scheduler\` job spec (id + gating fields), so PR 8 can register these with the scheduler when per-source backoff and freshness metadata land.

**Adding a new source is now one line in \`SOURCE_JOBS\`** instead of a fan-out edit in \`refreshAll()\`.

## What moved where

- POTA's \`activator → callsign\` field normalization: inline in \`fetchSourceData\` → declarative \`transform\` on the descriptor
- DXC SSE short-circuit (\`isDxcSseActive()\` check): inline in \`fetchSourceData\` → \`shortCircuit\` function on the descriptor
- RBN SSE short-circuit + \`rbn_source\` feature flag: same — moved to descriptor
- WSPR heatmap re-render side effect: stays in \`applySourceData\` (it's a UI update, not a fetch concern)

## What didn't change

- **Trigger semantics**: countdown still fires \`refreshAll()\`, manual button still fires \`refreshAll()\`, tab switch still fires \`fetchSourceData(source)\`
- **Auxiliary widget fetches** (solar, lunar, propagation, voacap, spacewx, dxpeditions, contests): still in \`refreshAll()\` — they don't share the \`SOURCE_DEFS\` shape and have widget-specific gates. They could be modeled as jobs in a follow-up
- **\`fetchSourceData(source)\` public API**: kept as a backward-compatible wrapper that looks up the descriptor and runs the same code path. Two new exports for introspection: \`getSourceJob(source)\`, \`listSourceJobs()\`

## Test plan
- [x] Build succeeds
- [x] All 7 source IDs present in bundled \`public/app.js\`
- [x] All 85 unit + smoke tests still pass
- [x] **Live browser smoke**: all six source tabs populate, POTA callsign column not blank (transform working), manual refresh fans out, auto-refresh countdown still drives the burst, clocks/spot ages/gray-line still tick (PR 6 carry-over checks)

## Out of scope
- Auxiliary widget fetches → could be modeled as jobs in a follow-up
- Per-source backoff, freshness metadata, scheduler registration → PR 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)