### PR TITLE
Visibility catch-up + update polling consolidation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -15819,14 +15819,35 @@ ${beacon.location}`);
     await executeJob(id);
     return true;
   }
+  function catchUpRenderJobs() {
+    for (const [id, entry] of jobs) {
+      if (entry.spec.manual) continue;
+      if (entry.spec.kind !== "render") continue;
+      if (!shouldRun(entry.spec, buildContext(entry.spec))) continue;
+      const sinceLastStart = Date.now() - (entry.state.lastStartedAt || 0);
+      if (sinceLastStart < 250) continue;
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+        entry.timer = null;
+      }
+      executeJob(id).then(() => scheduleNext(id));
+    }
+  }
   if (typeof window !== "undefined") {
     window.__hamtabScheduler = {
       list: listJobs,
       state: getJobState,
       all: getAllJobStates,
       runNow,
-      has
+      has,
+      catchUp: catchUpRenderJobs
     };
+  }
+  if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) return;
+      catchUpRenderJobs();
+    });
   }
 
   // src/refresh.js
@@ -25692,6 +25713,7 @@ ${beacon.location}`);
   init_state();
   init_dom();
   init_utils();
+  var UPDATE_STATUS_JOB_ID = "update-status-poll";
   async function checkUpdateStatus() {
     try {
       const resp = await fetch("/api/update/status");
@@ -25710,9 +25732,20 @@ ${beacon.location}`);
     }
   }
   function startUpdateStatusPolling() {
-    if (state_default.updateStatusPolling) clearInterval(state_default.updateStatusPolling);
+    if (state_default.updateStatusPolling) {
+      clearInterval(state_default.updateStatusPolling);
+      state_default.updateStatusPolling = null;
+    }
     checkUpdateStatus();
-    state_default.updateStatusPolling = setInterval(checkUpdateStatus, 3e4);
+    if (!has(UPDATE_STATUS_JOB_ID)) {
+      register({
+        id: UPDATE_STATUS_JOB_ID,
+        intervalMs: 3e4,
+        run: checkUpdateStatus,
+        requiresLeader: true,
+        kind: "fetch"
+      });
+    }
   }
   function pollForServer(attempts) {
     if (attempts <= 0) {
@@ -27572,17 +27605,6 @@ r6IHztIUIH85apHFFGAZkhMtrqHbhc8Er26EILCCHl/7vGS0dfj9WyT1urWcrRbu
     run: updateBeaconMarkers,
     widgetGate: "widget-beacons",
     kind: "render"
-  });
-  document.addEventListener("visibilitychange", () => {
-    if (document.hidden || !state_default.appInitialized) return;
-    updateClocks();
-    updateBigClock();
-    updateAnalogClock();
-    updateSpotAges();
-    updateGrayLine();
-    updateSunMarker();
-    if (isWidgetVisible("widget-beacons")) updateBeaconMarkers();
-    if (isWidgetVisible("widget-voacap") || state_default.hfPropOverlayBand) renderVoacapMatrix();
   });
   setInitApp(initApp);
   initWidgets();

--- a/src/fetch-scheduler.js
+++ b/src/fetch-scheduler.js
@@ -180,6 +180,39 @@ export async function runNow(id) {
   return true;
 }
 
+// Catch-up on tab visibility return.
+//
+// Browsers throttle setTimeout/setInterval in background tabs, so when
+// a tab returns to the foreground there can be up to `intervalMs` of
+// staleness before the next scheduled tick fires. This walks all
+// auto-scheduled render-kind jobs, runs the eligible ones immediately,
+// and reschedules the regular cadence.
+//
+// Only `kind: 'render'` jobs are caught up — fetch-kind jobs are
+// deliberately NOT caught up to avoid synchronized network bursts on
+// tab return. They tick on their normal cadence after visibility
+// returns; freshness comes from the next scheduled run, not catch-up.
+export function catchUpRenderJobs() {
+  for (const [id, entry] of jobs) {
+    if (entry.spec.manual) continue;
+    if (entry.spec.kind !== 'render') continue;
+    if (!shouldRun(entry.spec, buildContext(entry.spec))) continue;
+    // Skip jobs that started running very recently (avoid double-fire
+    // when a visibility event lands right next to a scheduled tick).
+    const sinceLastStart = Date.now() - (entry.state.lastStartedAt || 0);
+    if (sinceLastStart < 250) continue;
+    // Cancel any pending tick — we're firing immediately and will
+    // reschedule a fresh interval afterwards.
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+      entry.timer = null;
+    }
+    // Fire-and-reschedule. executeJob is async but we don't need to
+    // await — we just want each job to start its own promise chain.
+    executeJob(id).then(() => scheduleNext(id));
+  }
+}
+
 // Dev/debug helper: expose scheduler introspection on window so it's
 // reachable from the browser console as `__hamtabScheduler`.
 if (typeof window !== 'undefined') {
@@ -189,5 +222,16 @@ if (typeof window !== 'undefined') {
     all: getAllJobStates,
     runNow,
     has,
+    catchUp: catchUpRenderJobs,
   };
+}
+
+// Attach the visibility catch-up listener once at module load.
+// Browser-only — guarded by typeof checks so the module still loads
+// cleanly under Node test runtime.
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) return;
+    catchUpRenderJobs();
+  });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -263,20 +263,9 @@ registerJob({
 
 // DE/DX Info refresh — timer managed internally by dedx-info.js (1s for live clocks)
 
-// --- Hidden-tab catch-up ---
-// When the tab returns to foreground, immediately refresh visual state that was skipped.
-document.addEventListener('visibilitychange', () => {
-  if (document.hidden || !state.appInitialized) return;
-  // Catch up visual-only updates immediately.
-  updateClocks();
-  updateBigClock();
-  updateAnalogClock();
-  updateSpotAges();
-  updateGrayLine();
-  updateSunMarker();
-  if (isWidgetVisible('widget-beacons')) updateBeaconMarkers();
-  if (isWidgetVisible('widget-voacap') || state.hfPropOverlayBand) renderVoacapMatrix();
-});
+// Hidden-tab catch-up is owned by the fetch-scheduler — it listens for
+// visibilitychange and re-fires render-kind jobs immediately on return.
+// See src/fetch-scheduler.js → catchUpRenderJobs().
 
 setInitApp(initApp);
 

--- a/src/update.js
+++ b/src/update.js
@@ -4,6 +4,9 @@
 import state from './state.js';
 import { $ } from './dom.js';
 import { fmtTime } from './utils.js';
+import { register as registerJob, has as hasJob, unregister as unregisterJob } from './fetch-scheduler.js';
+
+const UPDATE_STATUS_JOB_ID = 'update-status-poll';
 
 export async function checkUpdateStatus() {
   try {
@@ -30,9 +33,34 @@ export async function checkUpdateStatus() {
 }
 
 export function startUpdateStatusPolling() {
-  if (state.updateStatusPolling) clearInterval(state.updateStatusPolling);
+  // Clean up any legacy timer in case of hot reload.
+  if (state.updateStatusPolling) {
+    clearInterval(state.updateStatusPolling);
+    state.updateStatusPolling = null;
+  }
+  // Fire once immediately so the indicator updates without waiting 30s.
   checkUpdateStatus();
-  state.updateStatusPolling = setInterval(checkUpdateStatus, 30000);
+  // Register with the scheduler for the recurring poll. Leader-only so
+  // follower tabs don't independently poll the update endpoint.
+  if (!hasJob(UPDATE_STATUS_JOB_ID)) {
+    registerJob({
+      id: UPDATE_STATUS_JOB_ID,
+      intervalMs: 30000,
+      run: checkUpdateStatus,
+      requiresLeader: true,
+      kind: 'fetch',
+    });
+  }
+}
+
+export function stopUpdateStatusPolling() {
+  if (state.updateStatusPolling) {
+    clearInterval(state.updateStatusPolling);
+    state.updateStatusPolling = null;
+  }
+  if (hasJob(UPDATE_STATUS_JOB_ID)) {
+    unregisterJob(UPDATE_STATUS_JOB_ID);
+  }
 }
 
 function pollForServer(attempts) {


### PR DESCRIPTION
## Summary
PR 9 of the API modularization plan. Final consolidation: moves the remaining scattered visibility/polling logic under the fetch-scheduler. After this PR, the scheduler is the single authority for all periodic work.

## Visibility catch-up

Moves the \`visibilitychange\` handler from \`main.js\` into the scheduler. When the tab returns to foreground, \`catchUpRenderJobs()\` walks all auto-scheduled jobs with \`kind: 'render'\`, runs the eligible ones immediately (re-checking the normal \`shouldRun\` gates), and reschedules the regular cadence.

**Only render-kind jobs are caught up.** Fetch-kind jobs are deliberately NOT caught up to avoid synchronized network bursts on tab return. This matches the previous \`main.js\` handler's intent — it only re-fired \`updateClocks\` / \`updateGrayLine\` / \`updateBeaconMarkers\` / \`renderVoacapMatrix\`, never the satellite/PSK/VOACAP fetches. Now that intent is encoded as a scheduler policy (\`kind === 'render'\`) instead of an inline list.

Includes a 250ms debounce to avoid double-firing if a visibility event lands right next to a scheduled tick. Exposed as \`window.__hamtabScheduler.catchUp()\` for manual invocation.

## Update polling migration

\`src/update.js\` previously had its own \`setInterval(checkUpdateStatus, 30000)\` — the last scattered timer outside the scheduler. Migrated to a regular scheduler job (\`update-status-poll\`) with \`requiresLeader: true\` so follower tabs no longer independently poll the update endpoint.

\`startUpdateStatusPolling()\` registers the job; \`stopUpdateStatusPolling()\` unregisters it. Initial fire-once-immediately preserved so the indicator updates without waiting 30s.

## main.js cleanup

Removes the duplicate \`visibilitychange\` handler block. Replaced with a one-line pointer comment to the scheduler.

## Test plan
- [x] Build clean, all 105 tests still pass
- [x] **Live browser smoke**:
  - Clocks jump immediately on tab return (catch-up working)
  - \`__hamtabScheduler.state('clocks').lastSucceededAt\` updates within ms of tab return
  - Fetch jobs do NOT immediately update on tab return (verified by checking \`iss-position.lastSucceededAt\` before/after)
  - \`__hamtabScheduler.list()\` includes \`'update-status-poll'\` (18 jobs total when auto-refresh is enabled)
  - \`__hamtabScheduler.state('update-status-poll')\` shows the standard tracking record (lastFailedAt populated since /api/update/status 404s on main, consecutiveFailures incrementing, exponential backoff applied)

## Phase 2 status

After this PR merges, the entire scheduler workstream (PRs 6-9) is complete:

- **PR 6** — Fetch scheduler with declarative job model + 10 timer migrations
- **PR 7** — Source fetching refactored around job specs (3-layer split)
- **PR 8** — Per-job tracking + exponential backoff + manual mode
- **PR 9** — Visibility catch-up + update polling consolidation

\`__hamtabScheduler.list()\` is now the canonical answer to \"what periodic work does this app do?\" There are no more \`setInterval\` calls outside the scheduler in \`src/main.js\`, \`src/refresh.js\`, or \`src/update.js\`.

## Out of scope
- **Server response headers** (\`X-Hamtab-Fetched-At\`, etc.) — separate small server-side PR
- **BroadcastChannel shared-fetch** — explicitly noted as future work in the original spec, not coupled to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)