### PR TITLE
Add X-Hamtab-* freshness headers on cached endpoints

### DIFF
--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -6,6 +6,7 @@ const express = require('express');
 const satellite = require('satellite.js');
 const { fetchJSON, fetchText } = require('../services/http-fetch');
 const { registerCache } = require('../services/cache-store');
+const { setFreshnessHeaders } = require('../services/freshness-headers');
 
 const router = express.Router();
 
@@ -39,6 +40,7 @@ router.get('/satellites/list', async (req, res) => {
   try {
     // Return cached data if fresh
     if (satListCache.data && Date.now() < satListCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: satListCache.fetchedAt, expires: satListCache.expires, cacheHit: true });
       return res.json(satListCache.data);
     }
 
@@ -52,7 +54,9 @@ router.get('/satellites/list', async (req, res) => {
       intDesignator: s.intDesignator,
     }));
 
-    satListCache = { data: satellites, expires: Date.now() + SAT_LIST_TTL };
+    const now = Date.now();
+    satListCache = { data: satellites, fetchedAt: now, expires: now + SAT_LIST_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: satListCache.expires, cacheHit: false });
     res.json(satellites);
   } catch (err) {
     console.error('Error fetching satellite list:', err.message);
@@ -90,6 +94,7 @@ router.get('/satellites/positions', async (req, res) => {
   // Cache key includes IDs + rounded observer coords (~1.1 km granularity)
   const cacheKey = `${satIds.sort().join(',')}:${obsLat.toFixed(2)}:${obsLon.toFixed(2)}`;
   if (satPosCache.key === cacheKey && satPosCache.data && Date.now() < satPosCache.expires) {
+    setFreshnessHeaders(res, { fetchedAt: satPosCache.fetchedAt, expires: satPosCache.expires, cacheHit: true });
     return res.json(satPosCache.data);
   }
 
@@ -121,7 +126,9 @@ router.get('/satellites/positions', async (req, res) => {
       }
     }));
 
-    satPosCache = { data: positions, expires: Date.now() + SAT_POS_TTL, key: cacheKey };
+    const now = Date.now();
+    satPosCache = { data: positions, fetchedAt: now, expires: now + SAT_POS_TTL, key: cacheKey };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: satPosCache.expires, cacheHit: false });
     res.json(positions);
   } catch (err) {
     console.error('Error fetching satellite positions:', err.message);
@@ -154,6 +161,7 @@ router.get('/satellites/passes', async (req, res) => {
   const cacheKey = `${id}:${obsLat.toFixed(2)}:${obsLon.toFixed(2)}`;
   const cached = satPassCache[cacheKey];
   if (cached && Date.now() < cached.expires) {
+    setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
     return res.json(cached.data);
   }
 
@@ -182,12 +190,14 @@ router.get('/satellites/passes', async (req, res) => {
     };
 
     if (Object.keys(satPassCache).length >= SAT_PASS_MAX) {
-      const now = Date.now();
+      const evictNow = Date.now();
       for (const k of Object.keys(satPassCache)) {
-        if (satPassCache[k].expires < now) delete satPassCache[k];
+        if (satPassCache[k].expires < evictNow) delete satPassCache[k];
       }
     }
-    satPassCache[cacheKey] = { data: result, expires: Date.now() + SAT_PASS_TTL };
+    const now = Date.now();
+    satPassCache[cacheKey] = { data: result, fetchedAt: now, expires: now + SAT_PASS_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: satPassCache[cacheKey].expires, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('Error fetching satellite passes:', err.message);
@@ -210,6 +220,7 @@ router.get('/satellites/tle', async (req, res) => {
   // Check cache
   const cached = satTleCache[id];
   if (cached && Date.now() < cached.expires) {
+    setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
     return res.json(cached.data);
   }
 
@@ -224,12 +235,14 @@ router.get('/satellites/tle', async (req, res) => {
     };
 
     if (Object.keys(satTleCache).length >= SAT_TLE_MAX) {
-      const now = Date.now();
+      const evictNow = Date.now();
       for (const k of Object.keys(satTleCache)) {
-        if (satTleCache[k].expires < now) delete satTleCache[k];
+        if (satTleCache[k].expires < evictNow) delete satTleCache[k];
       }
     }
-    satTleCache[id] = { data: result, expires: Date.now() + SAT_TLE_TTL };
+    const now = Date.now();
+    satTleCache[id] = { data: result, fetchedAt: now, expires: now + SAT_TLE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: satTleCache[id].expires, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('Error fetching satellite TLE:', err.message);
@@ -305,6 +318,7 @@ router.get('/iss/position', async (req, res) => {
 
   // Return cached data if fresh and same observer
   if (issComputedCache.data && Date.now() < issComputedCache.expires && issComputedCache.obsKey === obsKey) {
+    setFreshnessHeaders(res, { fetchedAt: issComputedCache.fetchedAt, expires: issComputedCache.expires, cacheHit: true });
     return res.json(issComputedCache.data);
   }
 
@@ -366,7 +380,9 @@ router.get('/iss/position', async (req, res) => {
       orbitPath,
     };
 
-    issComputedCache = { data: result, expires: Date.now() + ISS_COMPUTED_TTL, obsKey };
+    const cacheNow = Date.now();
+    issComputedCache = { data: result, fetchedAt: cacheNow, expires: cacheNow + ISS_COMPUTED_TTL, obsKey };
+    setFreshnessHeaders(res, { fetchedAt: cacheNow, expires: issComputedCache.expires, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('Error computing ISS position:', err.message);

--- a/server/routes/solar.js
+++ b/server/routes/solar.js
@@ -7,6 +7,7 @@ const express = require('express');
 const { XMLParser } = require('fast-xml-parser');
 const { fetchJSON, fetchText, isPrivateIP, resolveHost, secureFetch } = require('../services/http-fetch');
 const { registerCache } = require('../services/cache-store');
+const { setFreshnessHeaders } = require('../services/freshness-headers');
 
 const router = express.Router();
 
@@ -190,13 +191,16 @@ router.get('/spacewx/history', async (req, res) => {
     // Return cached data if fresh
     const cached = spacewxCache[type];
     if (cached && Date.now() < cached.expires) {
+      setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
       return res.json(cached.data);
     }
 
     const raw = await fetchJSON(SPACEWX_URLS[type]);
     const data = normalizeSpacewx(type, raw);
 
-    spacewxCache[type] = { data, expires: Date.now() + SPACEWX_TTL };
+    const now = Date.now();
+    spacewxCache[type] = { data, fetchedAt: now, expires: now + SPACEWX_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: spacewxCache[type].expires, cacheHit: false });
     res.json(data);
   } catch (err) {
     console.error(`Error fetching spacewx ${type}:`, err.message);
@@ -830,6 +834,7 @@ function parseDatePart(monthStr, day, year) {
 router.get('/dxpeditions', async (req, res) => {
   try {
     if (dxpeditionCache.data && Date.now() < dxpeditionCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: dxpeditionCache.fetchedAt, expires: dxpeditionCache.expires, cacheHit: true });
       return res.json(dxpeditionCache.data);
     }
 
@@ -853,8 +858,11 @@ router.get('/dxpeditions', async (req, res) => {
         return aDate - bDate;
       });
 
+    const now = Date.now();
     dxpeditionCache.data = results;
-    dxpeditionCache.expires = Date.now() + DXPEDITION_TTL;
+    dxpeditionCache.fetchedAt = now;
+    dxpeditionCache.expires = now + DXPEDITION_TTL;
+    setFreshnessHeaders(res, { fetchedAt: now, expires: dxpeditionCache.expires, cacheHit: false });
     res.json(results);
   } catch (err) {
     console.error('Error fetching DXpeditions:', err.message);
@@ -931,6 +939,7 @@ function parseContestItem(item) {
 router.get('/contests', async (req, res) => {
   try {
     if (contestCache.data && Date.now() < contestCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: contestCache.fetchedAt, expires: contestCache.expires, cacheHit: true });
       return res.json(contestCache.data);
     }
 
@@ -957,8 +966,11 @@ router.get('/contests', async (req, res) => {
         return aDate - bDate;
       });
 
+    const now = Date.now();
     contestCache.data = results;
-    contestCache.expires = Date.now() + CONTEST_TTL;
+    contestCache.fetchedAt = now;
+    contestCache.expires = now + CONTEST_TTL;
+    setFreshnessHeaders(res, { fetchedAt: now, expires: contestCache.expires, cacheHit: false });
     res.json(results);
   } catch (err) {
     console.error('Error fetching contests:', err.message);
@@ -1067,6 +1079,7 @@ const DRAP_TTL = 5 * 60 * 1000; // 5 min — SWPC updates ~every 1-2 min but dat
 router.get('/drap/data', async (req, res) => {
   try {
     if (drapDataCache.data && Date.now() < drapDataCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: drapDataCache.fetchedAt, expires: drapDataCache.expires, cacheHit: true });
       return res.json(drapDataCache.data);
     }
     const url = 'https://services.swpc.noaa.gov/text/drap_global_frequencies.txt';
@@ -1097,8 +1110,11 @@ router.get('/drap/data', async (req, res) => {
     }
 
     const result = { lons, rows };
+    const now = Date.now();
     drapDataCache.data = result;
-    drapDataCache.expires = Date.now() + DRAP_TTL;
+    drapDataCache.fetchedAt = now;
+    drapDataCache.expires = now + DRAP_TTL;
+    setFreshnessHeaders(res, { fetchedAt: now, expires: drapDataCache.expires, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('Error fetching D-RAP data:', err.message);

--- a/server/routes/spots.js
+++ b/server/routes/spots.js
@@ -8,6 +8,7 @@ const net = require('net');
 const { XMLParser } = require('fast-xml-parser');
 const { secureFetch, fetchJSON, fetchText } = require('../services/http-fetch');
 const { registerCache } = require('../services/cache-store');
+const { setFreshnessHeaders } = require('../services/freshness-headers');
 const { isUSCallsign, lookupHamqth, gridToLatLon } = require('./callsign');
 
 const router = express.Router();
@@ -784,6 +785,7 @@ router.get('/spots/dxc', async (req, res) => {
   try {
     // Return cached data if fresh
     if (dxcCache.data && Date.now() < dxcCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: dxcCache.fetchedAt, expires: dxcCache.expires, cacheHit: true });
       return res.json(dxcCache.data);
     }
 
@@ -848,8 +850,9 @@ router.get('/spots/dxc', async (req, res) => {
     }
 
     // Cache the result
-    dxcCache = { data: spots, expires: Date.now() + DXC_CACHE_TTL };
-
+    const now = Date.now();
+    dxcCache = { data: spots, fetchedAt: now, expires: now + DXC_CACHE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: dxcCache.expires, cacheHit: false });
     res.json(spots);
   } catch (err) {
     console.error('Error fetching DXC spots:', err.message);
@@ -862,19 +865,26 @@ router.get('/spots/psk', async (req, res) => {
   try {
     // Return cached data if fresh
     if (pskCache.data && Date.now() < pskCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: pskCache.fetchedAt, expires: pskCache.expires, cacheHit: true });
       return res.json(pskCache.data);
     }
 
     // Circuit breaker check — serve stale if breaker is open
     // Global PSK returns a plain array (consumed by source tab), so no _meta wrapper
     if (!pskCbAllowRequest()) {
-      if (pskCache.data) return res.json(pskCache.data);
+      if (pskCache.data) {
+        setFreshnessHeaders(res, { fetchedAt: pskCache.fetchedAt, expires: pskCache.expires, cacheHit: true });
+        return res.json(pskCache.data);
+      }
       return res.status(503).json({ error: 'PSKReporter circuit breaker open — try again shortly' });
     }
 
     // Rate limit check — serve stale data if throttled
     if (!pskAcquireToken(pskGlobalBucket)) {
-      if (pskCache.data) return res.json(pskCache.data); // stale-while-revalidate
+      if (pskCache.data) {
+        setFreshnessHeaders(res, { fetchedAt: pskCache.fetchedAt, expires: pskCache.expires, cacheHit: true });
+        return res.json(pskCache.data);
+      }
       return res.status(429).json({ error: 'PSKReporter rate limit — try again shortly' });
     }
 
@@ -901,7 +911,9 @@ router.get('/spots/psk', async (req, res) => {
     // Extract reception reports array
     const reports = doc.receptionReports?.receptionReport;
     if (!reports) {
-      pskCache = { data: [], expires: Date.now() + PSK_CACHE_TTL };
+      const now = Date.now();
+      pskCache = { data: [], fetchedAt: now, expires: now + PSK_CACHE_TTL };
+      setFreshnessHeaders(res, { fetchedAt: now, expires: pskCache.expires, cacheHit: false });
       return res.json([]);
     }
 
@@ -942,13 +954,18 @@ router.get('/spots/psk', async (req, res) => {
     // Filter out spots with no valid transmitter coordinates
     const validSpots = spots.filter(s => s.latitude !== null && s.longitude !== null);
 
-    pskCache = { data: validSpots, expires: Date.now() + PSK_CACHE_TTL };
+    const now = Date.now();
+    pskCache = { data: validSpots, fetchedAt: now, expires: now + PSK_CACHE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: pskCache.expires, cacheHit: false });
     res.json(validSpots);
   } catch (err) {
     console.error('Error fetching PSKReporter spots:', err.message);
     pskCbRecordFailure(); // track consecutive failures
     // Stale-while-revalidate — serve old data if available
-    if (pskCache.data) return res.json(pskCache.data);
+    if (pskCache.data) {
+      setFreshnessHeaders(res, { fetchedAt: pskCache.fetchedAt, expires: pskCache.expires, cacheHit: true });
+      return res.json(pskCache.data);
+    }
     res.status(502).json({ error: 'PSKReporter is unavailable — try again shortly' });
   }
 });
@@ -976,26 +993,35 @@ router.get('/spots/psk/heard', async (req, res) => {
     if (mqttConnected && mqttCallsigns[callsign]?.spots.size > 0) {
       const result = mqttBuildHeardResponse(callsign);
       // Also update the HTTP cache so stale fallback has fresh data
-      pskHeardCache[callsign] = { data: result, expires: Date.now() + PSK_HEARD_CACHE_TTL };
+      const now = Date.now();
+      pskHeardCache[callsign] = { data: result, fetchedAt: now, expires: now + PSK_HEARD_CACHE_TTL };
+      setFreshnessHeaders(res, { fetchedAt: now, expires: pskHeardCache[callsign].expires, cacheHit: false });
       return res.json(result);
     }
 
     // Check cache
     const cached = pskHeardCache[callsign];
     if (cached && Date.now() < cached.expires) {
+      setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
       return res.json(cached.data);
     }
 
     // Circuit breaker check — serve stale if breaker is open
     if (!pskCbAllowRequest()) {
       const meta = pskMeta(cached);
-      if (cached?.data) return res.json({ ...cached.data, _meta: meta });
+      if (cached?.data) {
+        setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
+        return res.json({ ...cached.data, _meta: meta });
+      }
       return res.status(503).json({ error: 'PSKReporter circuit breaker open — try again shortly' });
     }
 
     // Rate limit check — serve stale data if throttled
     if (!pskAcquireToken(pskHeardBucket)) {
-      if (cached?.data) return res.json(cached.data); // stale-while-revalidate
+      if (cached?.data) {
+        setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
+        return res.json(cached.data);
+      }
       return res.status(429).json({ error: 'PSKReporter rate limit — try again shortly' });
     }
 
@@ -1023,7 +1049,9 @@ router.get('/spots/psk/heard', async (req, res) => {
     const reports = doc.receptionReports?.receptionReport;
     if (!reports) {
       const result = { spots: [], summary: {} };
-      pskHeardCache[callsign] = { data: result, expires: Date.now() + PSK_HEARD_CACHE_TTL };
+      const now = Date.now();
+      pskHeardCache[callsign] = { data: result, fetchedAt: now, expires: now + PSK_HEARD_CACHE_TTL };
+      setFreshnessHeaders(res, { fetchedAt: now, expires: pskHeardCache[callsign].expires, cacheHit: false });
       return res.json(result);
     }
 
@@ -1087,14 +1115,19 @@ router.get('/spots/psk/heard', async (req, res) => {
     }
 
     const result = { spots: validSpots, summary };
-    pskHeardCache[callsign] = { data: result, expires: Date.now() + PSK_HEARD_CACHE_TTL };
+    const now = Date.now();
+    pskHeardCache[callsign] = { data: result, fetchedAt: now, expires: now + PSK_HEARD_CACHE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: pskHeardCache[callsign].expires, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('Error fetching PSKReporter heard spots:', err.message);
     pskCbRecordFailure(); // track consecutive failures
     // Stale-while-revalidate — serve old data if available
     const stale = pskHeardCache[callsign];
-    if (stale?.data) return res.json(stale.data);
+    if (stale?.data) {
+      setFreshnessHeaders(res, { fetchedAt: stale.fetchedAt, expires: stale.expires, cacheHit: true });
+      return res.json(stale.data);
+    }
     res.status(502).json({ error: 'PSKReporter is unavailable — try again shortly' });
   }
 });
@@ -1182,7 +1215,9 @@ router.post('/internal/psk-parse', express.text({ type: '*/*', limit: '5mb' }), 
     const reports = parsePskSpots(req.body);
     const spots = reports.map(transformPskSpot);
     const validSpots = spots.filter(s => s.latitude !== null && s.longitude !== null);
-    pskCache = { data: validSpots, expires: Date.now() + PSK_CACHE_TTL };
+    const now = Date.now();
+    pskCache = { data: validSpots, fetchedAt: now, expires: now + PSK_CACHE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: pskCache.expires, cacheHit: false });
     res.json(validSpots);
   } catch (err) {
     console.error('[internal/psk-parse] Error:', err.message);
@@ -1210,7 +1245,9 @@ router.post('/internal/psk-heard-parse', express.text({ type: '*/*', limit: '5mb
       }
     }
     const result = { spots: validSpots, summary };
-    if (callsign) pskHeardCache[callsign] = { data: result, expires: Date.now() + PSK_HEARD_CACHE_TTL };
+    const now = Date.now();
+    if (callsign) pskHeardCache[callsign] = { data: result, fetchedAt: now, expires: now + PSK_HEARD_CACHE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: now + PSK_HEARD_CACHE_TTL, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('[internal/psk-heard-parse] Error:', err.message);
@@ -1225,6 +1262,7 @@ const WSPR_CACHE_TTL = 5 * 60 * 1000; // 5 min — WSPR 2-min cycle; 20 req/min 
 router.get('/spots/wspr', async (req, res) => {
   try {
     if (wsprCache.data && Date.now() < wsprCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: wsprCache.fetchedAt, expires: wsprCache.expires, cacheHit: true });
       return res.json(wsprCache.data);
     }
 
@@ -1267,7 +1305,9 @@ router.get('/spots/wspr', async (req, res) => {
     // Filter out spots with no valid transmitter coordinates
     const validSpots = spots.filter(s => s.latitude !== null && s.longitude !== null);
 
-    wsprCache = { data: validSpots, expires: Date.now() + WSPR_CACHE_TTL };
+    const now = Date.now();
+    wsprCache = { data: validSpots, fetchedAt: now, expires: now + WSPR_CACHE_TTL };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: wsprCache.expires, cacheHit: false });
     res.json(validSpots);
   } catch (err) {
     console.error('Error fetching WSPR spots:', err.message);

--- a/server/routes/voacap.js
+++ b/server/routes/voacap.js
@@ -6,13 +6,14 @@ const express = require('express');
 const { XMLParser } = require('fast-xml-parser');
 const { fetchJSON, fetchText } = require('../services/http-fetch');
 const { registerCache } = require('../services/cache-store');
+const { setFreshnessHeaders } = require('../services/freshness-headers');
 const voacap = require('../../voacap-bridge.js');
 
 const router = express.Router();
 
 // --- SSN cache ---
 
-const ssnCache = { data: null, expires: 0 };
+const ssnCache = { data: null, fetchedAt: 0, expires: 0 };
 const SSN_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
 async function getCurrentSSN() {
@@ -57,6 +58,7 @@ async function getCurrentSSN() {
       };
     }
 
+    ssnCache.fetchedAt = Date.now();
     ssnCache.expires = Date.now() + SSN_TTL;
     return ssnCache.data;
   } catch (err) {
@@ -398,7 +400,14 @@ function parseSolarXML(xml) {
 // Return SSN data
 router.get('/voacap/ssn', async (req, res) => {
   try {
+    // Snapshot cache state before getCurrentSSN may overwrite it.
+    const wasCached = ssnCache.data && Date.now() < ssnCache.expires;
     const ssn = await getCurrentSSN();
+    setFreshnessHeaders(res, {
+      fetchedAt: ssnCache.fetchedAt || Date.now(),
+      expires: ssnCache.expires,
+      cacheHit: wasCached,
+    });
     res.json(ssn);
   } catch (err) {
     console.error('Error fetching SSN:', err.message);
@@ -487,6 +496,7 @@ router.get('/voacap', async (req, res) => {
 
     const cached = voacapCache[cacheKey];
     if (cached && Date.now() < cached.expires) {
+      setFreshnessHeaders(res, { fetchedAt: cached.fetchedAt, expires: cached.expires, cacheHit: true });
       return res.json(cached.data);
     }
 
@@ -584,7 +594,7 @@ router.get('/voacap', async (req, res) => {
                 month,
                 matrix: result.matrix,
               };
-              voacapCache[cacheKey] = { data: bgResponse, expires: Date.now() + VOACAP_TTL };
+              voacapCache[cacheKey] = { data: bgResponse, fetchedAt: Date.now(), expires: Date.now() + VOACAP_TTL };
             }
           }).catch(bgErr => {
             console.error(`[VOACAP] Background prediction error: ${bgErr.message}`);
@@ -613,8 +623,9 @@ router.get('/voacap', async (req, res) => {
     if (fallbackReason) response.fallbackReason = fallbackReason;
 
     const ttl = engine === 'dvoacap' ? VOACAP_TTL : 30 * 1000; // 1h vs 30s
-    voacapCache[cacheKey] = { data: response, expires: Date.now() + ttl };
-
+    const now = Date.now();
+    voacapCache[cacheKey] = { data: response, fetchedAt: now, expires: now + ttl };
+    setFreshnessHeaders(res, { fetchedAt: now, expires: voacapCache[cacheKey].expires, cacheHit: false });
     res.json(response);
   } catch (err) {
     console.error('Error in /api/voacap:', err.message);

--- a/server/routes/weather.js
+++ b/server/routes/weather.js
@@ -7,6 +7,7 @@ const { URL } = require('url');
 const express = require('express');
 const { isPrivateIP, resolveHost, fetchJSON, fetchText, MAX_REDIRECTS, MAX_RESPONSE_BYTES } = require('../services/http-fetch');
 const { registerCache } = require('../services/cache-store');
+const { setFreshnessHeaders } = require('../services/freshness-headers');
 
 const router = express.Router();
 
@@ -278,6 +279,7 @@ router.get('/owm', async (req, res) => {
 router.get('/radar', async (req, res) => {
   try {
     if (radarCache.data && Date.now() < radarCache.expires) {
+      setFreshnessHeaders(res, { fetchedAt: radarCache.fetchedAt, expires: radarCache.expires, cacheHit: true });
       return res.json(radarCache.data);
     }
     const json = await fetchJSON('https://api.rainviewer.com/public/weather-maps.json');
@@ -288,8 +290,11 @@ router.get('/radar', async (req, res) => {
     }
     const latest = radar.past[radar.past.length - 1];
     const result = { host: json.host, path: latest.path, time: latest.time };
+    const now = Date.now();
     radarCache.data = result;
-    radarCache.expires = Date.now() + RADAR_TTL;
+    radarCache.fetchedAt = now;
+    radarCache.expires = now + RADAR_TTL;
+    setFreshnessHeaders(res, { fetchedAt: now, expires: radarCache.expires, cacheHit: false });
     res.json(result);
   } catch (err) {
     console.error('Error fetching weather radar:', err.message);

--- a/server/services/freshness-headers.js
+++ b/server/services/freshness-headers.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+// X-Hamtab-* freshness headers.
+//
+// Routes that serve cached upstream data call setFreshnessHeaders(res, opts)
+// to expose freshness metadata to clients without changing response shape.
+// Headers set:
+//
+//   X-Hamtab-Fetched-At    ISO timestamp of when the data was originally
+//                          fetched from upstream (or "now" for non-cached).
+//   X-Hamtab-Source-Age-Sec  Integer seconds since X-Hamtab-Fetched-At.
+//   X-Hamtab-Cache-Hit     "true" if served from cache, "false" if fresh.
+//   X-Hamtab-Stale         "true" if past expires, "false" otherwise.
+//
+// Clients (browser, curl, monitoring) can use these to detect stale data
+// without parsing response bodies. The fetch-scheduler client also tracks
+// success/failure independently in PR 8 — these headers are complementary.
+
+const HEADER_FETCHED_AT = 'X-Hamtab-Fetched-At';
+const HEADER_SOURCE_AGE = 'X-Hamtab-Source-Age-Sec';
+const HEADER_CACHE_HIT = 'X-Hamtab-Cache-Hit';
+const HEADER_STALE = 'X-Hamtab-Stale';
+
+// Set freshness headers on an Express response.
+//
+// opts:
+//   fetchedAt?: number    epoch ms of original fetch (defaults to now)
+//   expires?:   number    epoch ms of TTL expiry (optional)
+//   cacheHit?:  boolean   was this served from cache? (defaults to false)
+//
+// All four headers are always set so clients can rely on them being
+// present. If `expires` is omitted, X-Hamtab-Stale is "false".
+function setFreshnessHeaders(res, opts = {}) {
+  const now = Date.now();
+  const fetchedAt = typeof opts.fetchedAt === 'number' ? opts.fetchedAt : now;
+  const cacheHit = opts.cacheHit === true;
+  const ageSec = Math.max(0, Math.floor((now - fetchedAt) / 1000));
+  const stale = opts.expires != null && now > opts.expires;
+
+  res.set(HEADER_FETCHED_AT, new Date(fetchedAt).toISOString());
+  res.set(HEADER_SOURCE_AGE, String(ageSec));
+  res.set(HEADER_CACHE_HIT, cacheHit ? 'true' : 'false');
+  res.set(HEADER_STALE, stale ? 'true' : 'false');
+}
+
+module.exports = {
+  setFreshnessHeaders,
+  HEADER_FETCHED_AT,
+  HEADER_SOURCE_AGE,
+  HEADER_CACHE_HIT,
+  HEADER_STALE,
+};

--- a/test/unit/freshness-headers.test.js
+++ b/test/unit/freshness-headers.test.js
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 SF Foundry. MIT License.
+// SPDX-License-Identifier: MIT
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  setFreshnessHeaders,
+  HEADER_FETCHED_AT,
+  HEADER_SOURCE_AGE,
+  HEADER_CACHE_HIT,
+  HEADER_STALE,
+} = require('../../server/services/freshness-headers');
+
+// Build a fake Express response that records header sets.
+function fakeRes() {
+  const headers = {};
+  return {
+    headers,
+    set: (k, v) => { headers[k] = v; },
+  };
+}
+
+describe('setFreshnessHeaders — defaults', () => {
+  test('with no opts: cache miss, fetched now, age 0, not stale', () => {
+    const res = fakeRes();
+    setFreshnessHeaders(res);
+    assert.equal(res.headers[HEADER_CACHE_HIT], 'false');
+    assert.equal(res.headers[HEADER_SOURCE_AGE], '0');
+    assert.equal(res.headers[HEADER_STALE], 'false');
+    // Fetched-at is an ISO string near "now"
+    const ms = Date.parse(res.headers[HEADER_FETCHED_AT]);
+    assert.ok(Math.abs(Date.now() - ms) < 5000);
+  });
+});
+
+describe('setFreshnessHeaders — cache hit', () => {
+  test('reports correct age for a cache entry from 30 seconds ago', () => {
+    const res = fakeRes();
+    const fetchedAt = Date.now() - 30_000;
+    const expires = Date.now() + 30_000;
+    setFreshnessHeaders(res, { fetchedAt, expires, cacheHit: true });
+    assert.equal(res.headers[HEADER_CACHE_HIT], 'true');
+    assert.equal(res.headers[HEADER_STALE], 'false');
+    // Age should be ~30s (allow small clock drift)
+    const age = parseInt(res.headers[HEADER_SOURCE_AGE], 10);
+    assert.ok(age >= 29 && age <= 31, `expected age ~30, got ${age}`);
+    assert.equal(res.headers[HEADER_FETCHED_AT], new Date(fetchedAt).toISOString());
+  });
+
+  test('reports stale=true when expires has passed', () => {
+    const res = fakeRes();
+    const fetchedAt = Date.now() - 120_000;
+    const expires = Date.now() - 60_000; // expired a minute ago
+    setFreshnessHeaders(res, { fetchedAt, expires, cacheHit: true });
+    assert.equal(res.headers[HEADER_STALE], 'true');
+    assert.equal(res.headers[HEADER_CACHE_HIT], 'true');
+    const age = parseInt(res.headers[HEADER_SOURCE_AGE], 10);
+    assert.ok(age >= 119 && age <= 121);
+  });
+});
+
+describe('setFreshnessHeaders — cache miss', () => {
+  test('after fresh fetch with explicit timestamps', () => {
+    const res = fakeRes();
+    const now = Date.now();
+    setFreshnessHeaders(res, { fetchedAt: now, expires: now + 60_000, cacheHit: false });
+    assert.equal(res.headers[HEADER_CACHE_HIT], 'false');
+    assert.equal(res.headers[HEADER_STALE], 'false');
+    assert.equal(res.headers[HEADER_SOURCE_AGE], '0');
+    assert.equal(res.headers[HEADER_FETCHED_AT], new Date(now).toISOString());
+  });
+});
+
+describe('setFreshnessHeaders — edge cases', () => {
+  test('clamps negative age to 0 (clock skew)', () => {
+    const res = fakeRes();
+    // fetchedAt in the future (clock skew or test artifact)
+    setFreshnessHeaders(res, { fetchedAt: Date.now() + 5000 });
+    assert.equal(res.headers[HEADER_SOURCE_AGE], '0');
+  });
+
+  test('omitting expires defaults to stale=false', () => {
+    const res = fakeRes();
+    setFreshnessHeaders(res, { fetchedAt: Date.now() - 1000, cacheHit: false });
+    assert.equal(res.headers[HEADER_STALE], 'false');
+  });
+
+  test('cacheHit defaults to false on truthy non-boolean inputs', () => {
+    const res = fakeRes();
+    setFreshnessHeaders(res, { cacheHit: 'true' }); // string, not boolean
+    assert.equal(res.headers[HEADER_CACHE_HIT], 'false');
+  });
+
+  test('always sets all four headers (clients can rely on presence)', () => {
+    const res = fakeRes();
+    setFreshnessHeaders(res);
+    assert.ok(HEADER_FETCHED_AT in res.headers);
+    assert.ok(HEADER_SOURCE_AGE in res.headers);
+    assert.ok(HEADER_CACHE_HIT in res.headers);
+    assert.ok(HEADER_STALE in res.headers);
+  });
+});


### PR DESCRIPTION
## Summary
Completes the server-side half of PR 8's freshness story (the client-side scheduler tracking landed in #160). Each cached route now sets four headers so clients (browser DevTools, curl, monitoring, etc.) can detect data freshness without parsing response bodies.

## Headers

\`\`\`
X-Hamtab-Fetched-At      ISO timestamp of original upstream fetch
X-Hamtab-Source-Age-Sec  integer seconds since fetch
X-Hamtab-Cache-Hit       "true" if served from cache, else "false"
X-Hamtab-Stale           "true" if past expires, else "false"
\`\`\`

All four headers are always set so clients can rely on presence.

## Architecture

**New: \`server/services/freshness-headers.js\`** — single helper \`setFreshnessHeaders(res, opts)\`. Pure logic, fully unit-tested. Negative ages are clamped to 0 to handle clock skew.

**Cache shape change:** cached entries now carry a \`fetchedAt\` timestamp alongside \`expires\`, so the helper can compute age accurately. Touched all 16 route-level cache write sites across 5 routers.

Internal helper caches (\`fetchCallCoords\`, \`fetchSummitCoords\`, \`getHamqthSessionId\`, \`scrapeSDODay\`, \`fetchIssTle\`) are NOT touched — they don't have a \`res\` object and their callers compute headers from the wrapping route-level cache.

## Routes covered

| Router | Routes |
|---|---|
| spots | \`/spots/dxc\`, \`/spots/psk\`, \`/spots/psk/heard\`, \`/spots/wspr\`, plus internal \`/internal/psk-parse\` and \`/internal/psk-heard-parse\` |
| weather | \`/weather/radar\` |
| satellites | \`/satellites/list\`, \`/satellites/positions\`, \`/satellites/passes\`, \`/satellites/tle\`, \`/iss/position\` |
| solar | \`/spacewx/history\`, \`/dxpeditions\`, \`/contests\`, \`/drap/data\` |
| voacap | \`/voacap\`, \`/voacap/ssn\` |

Routes that don't cache server-side (POTA, SOTA, WWFF, /weather, /weather/conditions, /weather/alerts, /weather/owm, /callsign) are deliberately NOT modified — they have no fetchedAt to report.

## Test plan

- [x] 8 new unit tests for the helper covering defaults, cache hit with age, stale detection, edge cases (clock skew, missing expires, truthy non-boolean cacheHit). All 113 tests pass.
- [x] **Live verified with curl**:

\`\`\`
$ curl -sI http://localhost:3000/api/spots/dxc | grep -i x-hamtab
X-Hamtab-Fetched-At: 2026-04-11T17:49:43.308Z
X-Hamtab-Source-Age-Sec: 0
X-Hamtab-Cache-Hit: false
X-Hamtab-Stale: false

# Second request within TTL:
$ curl -sI http://localhost:3000/api/spots/dxc | grep -i x-hamtab
X-Hamtab-Fetched-At: 2026-04-11T17:49:43.308Z   # ← same timestamp
X-Hamtab-Source-Age-Sec: 0
X-Hamtab-Cache-Hit: true                         # ← cache hit
X-Hamtab-Stale: false

# /api/voacap/ssn — long TTL, age increments between hits:
$ curl -sI http://localhost:3000/api/voacap/ssn | grep -i x-hamtab
X-Hamtab-Source-Age-Sec: 47
X-Hamtab-Cache-Hit: true
$ sleep 1; curl -sI http://localhost:3000/api/voacap/ssn | grep -i x-hamtab
X-Hamtab-Source-Age-Sec: 48                      # ← real-time age
X-Hamtab-Cache-Hit: true
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)